### PR TITLE
[DP-41] feat: input 컴포넌트 구현 #13

### DIFF
--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { useState } from "react";
 import InputComponent from "@/components/common/input/InputComponent";
 

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+import { useState } from "react";
+import InputComponent from "@/components/common/input/InputComponent";
+
+export default function MapPage() {
+  const [textValue, setTextValue] = useState("");
+  const [numberValue, setNumberValue] = useState("123");
+
+  return (
+    <div className="p-6 space-y-6 bg-gray-50 min-h-screen">
+      <h1 className="text-xl font-bold">InputComponent 테스트</h1>
+
+      {/* 텍스트 인풋 - lg */}
+      <InputComponent
+        radius="lg"
+        size="lg"
+        placeholder="텍스트 입력 인풋 필드 (lg)"
+        value={textValue}
+        onChange={(e) => setTextValue(e.target.value)}
+        type="text"
+        disabled={false}
+        required
+      />
+
+      {/* 숫자 인풋 - md */}
+      <InputComponent
+        radius="md"
+        size="md"
+        placeholder="숫자 입력 인풋 필드 (md)"
+        value={numberValue}
+        onChange={(e) => setNumberValue(e.target.value)}
+        className="w-full"
+        type="number"
+        disabled={false}
+      />
+
+      {/* 작은 인풋 - md */}
+      <InputComponent
+        radius="sm"
+        size="md"
+        placeholder="작은 인풋"
+        value={textValue}
+        onChange={(e) => setTextValue(e.target.value)}
+        disabled={false}
+      />
+
+      {/* disabled 테스트 */}
+      <InputComponent
+        radius="md"
+        size="md"
+        value="비활성화됨"
+        onChange={() => {}}
+        disabled
+      />
+    </div>
+  );
+} 

--- a/src/components/common/input/InputComponent.tsx
+++ b/src/components/common/input/InputComponent.tsx
@@ -1,0 +1,44 @@
+"use client";
+import { Input } from "@/components/ui/input";
+import { cn } from "@lib/utils";
+import { useMemo } from "react";
+
+type InputRadius = "lg" | "md"| "sm" | number;
+
+interface InputComponentProps {
+    color:string;
+    radius: InputRadius;
+    size: "sm" | "md" | "lg";
+    className: string;
+    placeholder: string;
+    value: string;
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+
+
+export default function InputComponent({color, radius, size, className, placeholder, value, onChange}:Partial<InputComponentProps>) {
+    const inputRadius = useMemo(()=>{
+        switch(radius) {
+            case "lg":
+                return "rounded-[12px]";
+            case "md":
+                return "rounded-[10px]";
+            case "sm":
+                return "rounded-[8px]";
+            default:
+                return `rounded-[${radius}px]`;
+        }
+    }, [radius]);
+    const inputSize = useMemo(()=>{
+        switch(size) {
+            case "sm":
+                return "h-[17px]";
+            case "md":
+                return "h-[48px]";
+            case "lg":
+                return "h-[105px]";
+        }
+    }, [size]);
+    return (<Input className={cn(className, inputRadius, inputSize, color)} placeholder={placeholder} value={value} onChange={onChange} />);
+}

--- a/src/components/common/input/InputComponent.tsx
+++ b/src/components/common/input/InputComponent.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { Input } from "@/components/ui/input";
 import { cn } from "@lib/utils";
 import { useMemo } from "react";

--- a/src/components/common/input/InputComponent.tsx
+++ b/src/components/common/input/InputComponent.tsx
@@ -3,23 +3,34 @@ import { Input } from "@/components/ui/input";
 import { cn } from "@lib/utils";
 import { useMemo } from "react";
 
-type InputRadius = "lg" | "md"| "sm" | number;
+type InputRadius = "lg" | "md" | "sm" | number;
 
 interface InputComponentProps {
-    color:string;
+    color: string;
     radius: InputRadius;
     size: "sm" | "md" | "lg";
     className: string;
     placeholder: string;
     value: string;
     onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    disabled: boolean;
+    type?: "text" | "number";
+    required?: boolean;
 }
 
-
-
-export default function InputComponent({color, radius, size, className, placeholder, value, onChange}:Partial<InputComponentProps>) {
-    const inputRadius = useMemo(()=>{
-        switch(radius) {
+export default function InputComponent({ 
+    color, 
+    radius, 
+    size, 
+    className, 
+    placeholder, 
+    value, 
+    onChange, 
+    disabled,
+    type = "text",
+    required, }: Partial<InputComponentProps>) {
+    const inputRadius = useMemo(() => {
+        switch (radius) {
             case "lg":
                 return "rounded-[12px]";
             case "md":
@@ -30,8 +41,8 @@ export default function InputComponent({color, radius, size, className, placehol
                 return `rounded-[${radius}px]`;
         }
     }, [radius]);
-    const inputSize = useMemo(()=>{
-        switch(size) {
+    const inputSize = useMemo(() => {
+        switch (size) {
             case "sm":
                 return "h-[17px]";
             case "md":
@@ -40,5 +51,12 @@ export default function InputComponent({color, radius, size, className, placehol
                 return "h-[105px]";
         }
     }, [size]);
-    return (<Input className={cn(className, inputRadius, inputSize, color)} placeholder={placeholder} value={value} onChange={onChange} />);
+    return (<Input 
+        className={cn(className, inputRadius, inputSize, color)} 
+        placeholder={placeholder} 
+        value={value} 
+        onChange={onChange} 
+        disabled={disabled}
+        type={type}
+        required={required} />);
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 
-const plugin = require("tailwindcss/plugin");
+import plugin from "tailwindcss/plugin";
 
 module.exports = {
   content: [


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->

- 디자인 시스템에 맞춘 InputComponent UI 컴포넌트 생성
- radius/size/color/type 등 커스터마이징 가능한 형태로 설계
- tailwind utility class와 props 조합으로 유연한 스타일 구성 가능
- map page에서 테스트 완료

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->

- Partial<InputComponentProps>로 prop 유연성 확보 (단, 실사용 시에는 필수값 전달 필요)
- useMemo로 radius, size 계산값을 메모이제이션하여 리렌더링 최적화

## 테스트 사진
<img width="378" height="432" alt="스크린샷 2025-07-11 오전 10 28 19" src="https://github.com/user-attachments/assets/08beb874-975d-43ad-b329-1aa32f9bb4de" />

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
