### PR TITLE
[DP-94] feat: 채팅방 진입 시 로고 헤더 숨김 처리 및 메시지 버블 정렬/시간 위치 개선 #74

### DIFF
--- a/src/app/chat/layout.tsx
+++ b/src/app/chat/layout.tsx
@@ -1,11 +1,18 @@
+"use client";
+
+import { usePathname } from "next/navigation";
 import { Fragment, ReactNode } from "react";
 import LogoHeader from "@components/common/header/LogoHeader";
 import BottomNavigation from "@components/common/navigation/BottomNavigation";
 
 export default function ChatLayout({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+
+  const isChatRoom = /^\/chat\/[^/]+$/.test(pathname);
+
   return (
     <Fragment>
-      <LogoHeader />
+      {!isChatRoom && <LogoHeader />}
       {children}
       <BottomNavigation />
     </Fragment>

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -12,7 +12,7 @@ export default function ChatListPage() {
       unreadCount: 2,
       avatarUrl: "/images/default-avatar.png",
       post: {
-        title: "2GB 데이터 판매",
+        title: "2GB",
         price: "2,000원",
       },
     },
@@ -24,7 +24,7 @@ export default function ChatListPage() {
       unreadCount: 0,
       avatarUrl: "/images/default-avatar.png",
       post: {
-        title: "6GB 데이터 판매",
+        title: "6GB",
         price: "3,000원",
       },
     },

--- a/src/components/common/navigation/BottomNavigation.tsx
+++ b/src/components/common/navigation/BottomNavigation.tsx
@@ -2,9 +2,12 @@ import { MapPin, MessageCircle, User, Wifi } from "lucide-react";
 import { Fragment } from "react";
 import NavigationButton from "./NavigationButton";
 
-export default async function BottomNavigation() {
+export default function BottomNavigation() {
   return (
-    <div className="fixed bottom-0 z-50 bg-white border-none overflow-x-clip" style={{ width: "375px" }}>
+    <div
+      className="fixed bottom-0 z-50 bg-white border-none overflow-x-clip"
+      style={{ width: "375px" }}
+    >
       <div className="grid grid-cols-4 px-8 shadow-nav">
         <NavigationButton target={"/data"}>
           <Fragment>

--- a/src/feature/chat/components/sections/list/ChatItem.tsx
+++ b/src/feature/chat/components/sections/list/ChatItem.tsx
@@ -42,6 +42,7 @@ export default function ChatItem({
         <AvatarIcon avatar={avatarUrl} size="medium" />
         <div className="flex flex-col gap-2">
           <span className="body-sm text-black">{name}</span>
+          <span className="body-sm text-gray-800">{post.title}</span>
           <span className="body-xs text-gray-600 truncate max-w-[180px]">{lastMessage}</span>
         </div>
       </div>

--- a/src/feature/chat/components/sections/room/ChatBubble.tsx
+++ b/src/feature/chat/components/sections/room/ChatBubble.tsx
@@ -14,7 +14,7 @@ export default function ChatBubble({ message, currentUserId }: ChatBubbleProps) 
   const timeText = formatTimeToAmPm(message.createdAt);
 
   const baseClasses =
-    "w-fit max-w-[244px] px-3 py-3 rounded-2xl whitespace-pre-wrap body-sm border border-primary-200 text-black";
+    "w-fit max-w-[70%] px-3 py-3 rounded-2xl whitespace-pre-wrap ml-4 body-sm border border-primary-200 text-black";
   const bubbleClasses = isMine ? "bg-primary2 rounded-br-none" : "bg-white rounded-bl-none";
 
   const bubble = <div className={cn(baseClasses, bubbleClasses)}>{message.text}</div>;
@@ -25,19 +25,17 @@ export default function ChatBubble({ message, currentUserId }: ChatBubbleProps) 
         <AvatarIcon avatar={message.senderAvatar ?? "/images/default-avatar.png"} size="small" />
       )}
 
-      <div className="flex flex-col items-start">
-        {isMine ? (
-          <>
-            {bubble}
-            <span className="body-xs text-gray-500 mt-1">{timeText}</span>
-          </>
-        ) : (
-          <div className="flex items-end gap-1">
-            {bubble}
-            <span className="body-xs text-gray-500">{timeText}</span>
-          </div>
-        )}
-      </div>
+      {isMine ? (
+        <div className="flex flex-row-reverse items-end gap-1">
+          {bubble}
+          <span className="body-xs text-gray-500 mt-1">{timeText}</span>
+        </div>
+      ) : (
+        <div className="flex items-end gap-1 w-full">
+          {bubble}
+          <span className="body-xs text-gray-500">{timeText}</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/feature/chat/components/sections/room/ChatPostCard.tsx
+++ b/src/feature/chat/components/sections/room/ChatPostCard.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Image from "next/image";
+
 interface ChatPostCardProps {
   title: string;
   price: string;
@@ -11,10 +13,12 @@ export default function ChatPostCard({ title, price }: ChatPostCardProps) {
 
   return (
     <div className="flex border border-primary-200 rounded-20 h-64 px-16 py-8 bg-white">
-      <img
+      <Image
         src={imageFile}
         alt={`${match?.[1]}GB 이미지`}
-        className="w-40 h-40 object-contain mr-12 shrink-0"
+        width={40}
+        height={40}
+        className="object-contain mr-12 shrink-0"
       />
       <div className="flex flex-col justify-center">
         <div className="body-sm text-gray-800">{title}</div>

--- a/src/feature/chat/components/sections/room/ChatPostCard.tsx
+++ b/src/feature/chat/components/sections/room/ChatPostCard.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+interface ChatPostCardProps {
+  title: string;
+  price: string;
+}
+
+export default function ChatPostCard({ title, price }: ChatPostCardProps) {
+  const match = title.match(/(\d+)GB/);
+  const imageFile = match ? `/${match[1]}.png` : "/default.png";
+
+  return (
+    <div className="flex border border-primary-200 rounded-20 h-64 px-16 py-8 bg-white">
+      <img
+        src={imageFile}
+        alt={`${match?.[1]}GB 이미지`}
+        className="w-40 h-40 object-contain mr-12 shrink-0"
+      />
+      <div className="flex flex-col justify-center">
+        <div className="body-sm text-gray-800">{title}</div>
+        <div className="title-sm text-secondary-600 mt-1">{price}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/feature/chat/components/sections/room/ChatRoomContent.tsx
+++ b/src/feature/chat/components/sections/room/ChatRoomContent.tsx
@@ -55,7 +55,7 @@ export default function ChatRoomContent({ title, price }: ChatRoomContentProps) 
         <ChatPostCard title={title} price={price} />
       </div>
 
-      {groupMessagesByDate(messages).map(({ date }) => (
+      {groupMessagesByDate(messages).map(({ date, messages }) => (
         <div key={date} className="space-y-6">
           <div className="text-center text-gray-500 body-xs py-6">{formatDateDivider(date)}</div>
           <div className="flex flex-col gap-24">

--- a/src/feature/chat/components/sections/room/ChatRoomContent.tsx
+++ b/src/feature/chat/components/sections/room/ChatRoomContent.tsx
@@ -58,13 +58,13 @@ export default function ChatRoomContent({ title, price }: ChatRoomContentProps) 
       {groupMessagesByDate(messages).map(({ date }) => (
         <div key={date} className="space-y-6">
           <div className="text-center text-gray-500 body-xs py-6">{formatDateDivider(date)}</div>
+          <div className="flex flex-col gap-24">
+            {messages.map((msg) => (
+              <ChatBubble key={msg.id} message={msg} currentUserId={currentUserId} />
+            ))}
+          </div>
         </div>
       ))}
-      <div className="flex flex-col gap-24">
-        {messages.map((msg) => (
-          <ChatBubble key={msg.id} message={msg} currentUserId={currentUserId} />
-        ))}
-      </div>
     </main>
   );
 }

--- a/src/feature/chat/components/sections/room/ChatRoomContent.tsx
+++ b/src/feature/chat/components/sections/room/ChatRoomContent.tsx
@@ -3,6 +3,9 @@
 //import { useSearchParams } from "next/navigation";
 import ChatBubble from "@feature/chat/components/sections/room/ChatBubble";
 import type { ChatMessage } from "@/feature/chat/types/message";
+import ChatPostCard from "./ChatPostCard";
+import { groupMessagesByDate } from "@feature/chat/utils/groupMessagesByDate";
+import { formatDateDivider } from "@lib/time";
 //import { useChatStream } from "@/feature/chat/hooks/useChatStream";
 //import { useProfileStore } from "@stores/useProfileStore";
 
@@ -14,7 +17,6 @@ export default function ChatRoomContent({ title, price }: ChatRoomContentProps) 
   const currentUserId = "123";
   //const searchParams = useSearchParams();
   //const chatId = searchParams.get("chatId") || "1"; // 예시
-
   //const currentUserAvatar = useProfileStore((state) => state.avatar);
 
   const messages: ChatMessage[] = [
@@ -48,14 +50,21 @@ export default function ChatRoomContent({ title, price }: ChatRoomContentProps) 
   ];
 
   return (
-    <main className="p-4 space-y-6 pb-24">
-      <div className="text-sm text-gray-500">
-        {title} · {price}
+    <main className="px-24 space-y-6 pt-24">
+      <div className="pb-48">
+        <ChatPostCard title={title} price={price} />
       </div>
 
-      {messages.map((msg) => (
-        <ChatBubble key={msg.id} message={msg} currentUserId={currentUserId} />
+      {groupMessagesByDate(messages).map(({ date }) => (
+        <div key={date} className="space-y-6">
+          <div className="text-center text-gray-500 body-xs py-6">{formatDateDivider(date)}</div>
+        </div>
       ))}
+      <div className="flex flex-col gap-24">
+        {messages.map((msg) => (
+          <ChatBubble key={msg.id} message={msg} currentUserId={currentUserId} />
+        ))}
+      </div>
     </main>
   );
 }

--- a/src/feature/chat/components/sections/room/ChatRoomHeader.tsx
+++ b/src/feature/chat/components/sections/room/ChatRoomHeader.tsx
@@ -2,13 +2,17 @@
 
 import { useRouter } from "next/navigation";
 import { MoreVertical, ChevronLeft } from "lucide-react";
+import { UserDropdownMenu } from "@components/common/dropdown/UserDropdownMenu";
+import { chatMenuOptions } from "@/components/common/dropdown/dropdownConfig";
 
 export default function ChatRoomHeader({ title }: { title: string }) {
   const router = useRouter();
-
+  const handleReport = () => {
+    alert("신고되었습니다.");
+  };
   return (
-    <div className="sticky top-0 z-50 bg-white shadow px-4 py-3 flex items-center justify-between">
-      <div className="flex items-center gap-2">
+    <div className="sticky top-0 z-50 bg-white shadow px-20 py-12 flex items-center justify-between">
+      <div className="flex items-center gap-8">
         <button onClick={() => router.back()}>
           <ChevronLeft className="w-5 h-5" />
         </button>
@@ -16,9 +20,11 @@ export default function ChatRoomHeader({ title }: { title: string }) {
         <h1 className="title-sm font-semibold text-gray-900">{title}</h1>
       </div>
 
-      <button className="p-1">
-        <MoreVertical className="w-5 h-5" />
-      </button>
+      <UserDropdownMenu options={chatMenuOptions(handleReport)}>
+        <button className="p-1">
+          <MoreVertical className="w-5 h-5" />
+        </button>
+      </UserDropdownMenu>
     </div>
   );
 }

--- a/src/feature/chat/utils/groupMessagesByDate.ts
+++ b/src/feature/chat/utils/groupMessagesByDate.ts
@@ -1,0 +1,19 @@
+import type { ChatMessage } from "@/feature/chat/types/message";
+
+//채팅 메시지를 날짜별로 그룹화
+export function groupMessagesByDate(messages: ChatMessage[]) {
+  const groups: { [date: string]: ChatMessage[] } = {};
+
+  messages.forEach((msg) => {
+    const date = msg.createdAt.split("T")[0];
+    if (!groups[date]) {
+      groups[date] = [];
+    }
+    groups[date].push(msg);
+  });
+
+  // 날짜 순 정렬해서 반환
+  return Object.entries(groups)
+    .sort(([a], [b]) => new Date(a).getTime() - new Date(b).getTime())
+    .map(([date, messages]) => ({ date, messages }));
+}

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -32,3 +32,11 @@ export function formatRelativeTime(iso: string, withSuffix = false): string {
 
   return withSuffix && result !== "방금" ? `${result} 전` : result;
 }
+
+export function formatDateDivider(isoOrDateString: string): string {
+  const date = new Date(isoOrDateString);
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  return `${year}년 ${month}월 ${day}일`;
+}


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 채팅방(/chat/[chatId]) 진입 시 LogoHeader가 중복되지 않도록 숨김 처리 (ChatLayout 조건 분기 적용)
- 메시지 버블 최대 너비를 %로 조정하여 반응형 대응 (max-w-[70%])
- 내가 보낸 메시지일 경우 시간 텍스트가 말풍선 왼쪽에 표시되도록 정렬 구조 변경
- 채팅 목록 아이템에서 사용자 정보 순서를 이름 → 제목 → 마지막 메시지로 변경
- groupMessagesByDate 유틸 파일명 명확화 고려 (분리 유지)
- 채팅방 상단 ChatRoomHeader에 공통 드롭다운(UserDropdownMenu)을 활용하여 "프로필 보기" / "신고하기" 옵션 추가

https://github.com/user-attachments/assets/f6d0f92d-707a-4b9d-a81c-37a7d2a074ce

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 채팅 상대 프로필 이동 링크는 임시 경로(/user/profile)여서 실제 사용자 ID 기반 라우팅으로 대체 예정입니다.
- 데이터 카드(ChatPostCard)는 현재 mock 기반으로 구성되어 있어서 추후 API 연동 진행할 예정
- 추후 연속 메시지 스타일 개선할 예정

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #74 

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
