### PR TITLE
[DP-65] fix: 배포 환경에 맞게 네이버 스크립트 수정 #50

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import ProviderWrapper from "@components/common/ProviderWrapper";
 import "./globals.css";
-import Script from "next/script";
+
 import BottomNavigation from "@components/common/navigation/BottomNavigation";
 
 export const metadata: Metadata = {
@@ -19,11 +19,6 @@ export default function RootLayout({
       <body className="flex flex-col min-h-screen w-full">
         <main className="antialiased flex-1 w-[375px] h-[812px] mx-auto overflow-hidden relative">
           <ProviderWrapper>
-            {/* 네이버 지도 API 스크립트 삽입 */}
-            <Script
-              strategy="beforeInteractive"
-              src={`https://openapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${process.env.NEXT_PUBLIC_NAVER_MAP_CLIENT_ID}&submodules=geocoder`}
-            />
             {children}
             <BottomNavigation />
           </ProviderWrapper>

--- a/src/app/map/layout.tsx
+++ b/src/app/map/layout.tsx
@@ -12,7 +12,7 @@ export default function MapLayout({ children }: { children: ReactNode }) {
       <main className="pt-[56px] pb-[56px]">
         {" "}
         <Script
-          strategy="beforeInteractive"
+          strategy="afterInteractive"
           src={`https://openapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${process.env.NEXT_PUBLIC_NAVER_MAP_CLIENT_ID}&submodules=geocoder`}
         />
         {children}


### PR DESCRIPTION
## 📌 작업 개요

- Vercel 배포 환경에서는
`<Script
  strategy="beforeInteractive"
  src="https://openapi.map.naver.com/openapi/v3/maps.js?..."
/>`
대신 afterInteractive로 수정해야 하기 때문에 해당 사항을 반영했습니다.

## ✨ 기타 참고 사항



## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
