### PR TITLE
[DP-178] feat: 와이파이 상품 구매 기능 API 연동 구현  #137

### DIFF
--- a/src/feature/map/components/pages/MapDetailPage.tsx
+++ b/src/feature/map/components/pages/MapDetailPage.tsx
@@ -6,21 +6,25 @@ import TopSheet from "@/components/common/topsheet/TopSheet";
 import { ButtonComponent } from "@components/common/button";
 import TimeSelectorSection from "@/feature/map/components/sections/product/TimeSelectorSection";
 import SellerSection from "@/feature/map/components/sections/seller/SellerSection";
-import { usePurchaseTimer } from "@/feature/map/hooks/usePurchaseTimer";
+// import { usePurchaseTimer } from "@/feature/map/hooks/usePurchaseTimer";
 import { useMapDetailData } from "@/feature/map/hooks/useMapDetailData";
 import { useTimeState } from "@/feature/map/hooks/useTimeState";
 import DeletePostModal from "@/feature/data/components/sections/modal/DeletePostModal";
-import { isValidTimeRange, parseHHMMToTime, isTimeInRange } from "@/lib/time";
+import { isValidTimeRange, parseHHMMToTime, isTimeInRange, formatTimeToHHMM } from "@/lib/time";
 import { useWifiPriceRecommendation } from "@/feature/map/hooks/useWifiPriceRecommendation";
+import { usePaymentStore } from "@feature/payment/stores/paymentStore";
 
 import clsx from "clsx";
+import { buildWifiPaymentInfo } from "@feature/payment/hooks/useWifiPurchaseBuilder";
+import UsePaymentModals from "@feature/payment/hooks/usePaymentModals";
 
 export default function MapDetailPage() {
   const router = useRouter();
   const { postId } = useParams<{ postId: string }>();
+  const { setInfo } = usePaymentStore();
 
   const [topSheetExpanded, setTopSheetExpanded] = useState(false);
-  const { handlePurchase } = usePurchaseTimer();
+  // const { handlePurchase } = usePurchaseTimer();
   const { data, isLoading, isError } = useMapDetailData(postId);
   const [error, setError] = useState<string | null>(null);
 
@@ -70,9 +74,15 @@ export default function MapDetailPage() {
     }
 
     setError(null);
-    handlePurchase(startTime, endTime, () => {
-      router.push("/data");
-    });
+
+    const start = formatTimeToHHMM(startTime);
+    const end = formatTimeToHHMM(endTime);
+
+    setInfo(buildWifiPaymentInfo(data, start, end));
+
+    // handlePurchase(startTime, endTime, () => {
+    //   router.push("/data");
+    // });
   };
 
   return (
@@ -127,6 +137,7 @@ export default function MapDetailPage() {
         </div>
       </div>
       <DeletePostModal isOpen={deleteModalOpen} setIsOpen={setDeleteModalOpen} />
+      <UsePaymentModals />
     </div>
   );
 }

--- a/src/feature/map/components/sections/product/TimeSelector.tsx
+++ b/src/feature/map/components/sections/product/TimeSelector.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { compareTimes } from "@/lib/time";
+import { compareTimesWithWraparound } from "@/lib/time";
 import type { Time } from "@type/Time";
 
 import { cn } from "@lib/utils";
@@ -88,8 +88,11 @@ export default function TimeSelector({
               period: rawTemp.period,
             };
 
-            const inMinRange = !minTime || compareTimes(tempTime, minTime) >= 0;
-            const inMaxRange = !maxTime || compareTimes(tempTime, maxTime) <= 0;
+            const inMinRange =
+              !minTime || compareTimesWithWraparound(tempTime, minTime, minTime) >= 0;
+            const inMaxRange =
+              !maxTime || compareTimesWithWraparound(tempTime, maxTime, minTime ?? maxTime) <= 0;
+
             const disabled = !inMinRange || !inMaxRange;
 
             const isSelected = itemStr === selectedValue;

--- a/src/feature/map/hooks/useMapDetailData.ts
+++ b/src/feature/map/hooks/useMapDetailData.ts
@@ -21,7 +21,9 @@ export const useMapDetailData = (id: string): UseMapDetailDataResult => {
 
   const mapDetailItem: MapDetailItem | undefined = detail
     ? {
+        itemId: detail.itemId,
         productId: detail.productId,
+        wifiId: detail.itemId,
         type: "와이파이",
         imageUrl: detail.imageUrls ?? [],
         place: detail.title,

--- a/src/feature/map/hooks/useRegisterFormValidation.ts
+++ b/src/feature/map/hooks/useRegisterFormValidation.ts
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { RegisterFormValues, RegisterFormErrors } from "@feature/map/types/registerForm";
+import { parseHHMMToTime, isValidTimeRange } from "@/lib/time";
 
 const initialErrors: RegisterFormErrors = {
   title: false,
@@ -39,12 +40,10 @@ export const useRegisterFormValidation = (form: RegisterFormValues) => {
       return false;
     }
 
-    const [sh, sm] = form.startTime.split(":").map(Number);
-    const [eh, em] = form.endTime.split(":").map(Number);
-    const start = sh * 60 + sm;
-    const end = eh * 60 + em;
+    const start = parseHHMMToTime(form.startTime);
+    const end = parseHHMMToTime(form.endTime);
 
-    if (start >= end) {
+    if (!isValidTimeRange(start, end)) {
       setErrors({ ...initialErrors, timeOrderInvalid: true });
       return false;
     }

--- a/src/feature/map/types/mapType.ts
+++ b/src/feature/map/types/mapType.ts
@@ -12,7 +12,9 @@ export interface MapType {
 }
 
 export type MapDetailItem = {
+  itemId: number | undefined;
   productId: number;
+  wifiId: number;
   type: string;
   imageUrl: string[];
   place: string;

--- a/src/feature/payment/api/paymentRequest.ts
+++ b/src/feature/payment/api/paymentRequest.ts
@@ -1,7 +1,11 @@
 import axios from "@lib/axios";
 import type { ScrapCombination } from "@feature/payment/types/paymentTypes";
 // 통합/분할 구매
-export const postDefaultTrade = async (productId: number, mobileDataId: number, dataAmount?: number) => {
+export const postDefaultTrade = async (
+  productId: number,
+  mobileDataId: number,
+  dataAmount?: number
+) => {
   const payload = {
     productId,
     mobileDataId,
@@ -22,6 +26,27 @@ export const postScrapTrade = async (
     totalPrice,
     combinations,
   });
-  console.log("자투리구매 api 호출",combinations)
+  console.log("자투리구매 api 호출", combinations);
+  return res.data.data.tradeId;
+};
+
+// 와이파이 구매
+export const postWifiTrade = async (
+  productId: number,
+  wifiId: number,
+  startTime: string,
+  endTime: string
+): Promise<number> => {
+  const res = await axios.post("/api/trades/wifi", {
+    productId,
+    wifiId,
+    startTime,
+    endTime,
+  });
+
+  if (res.data.code !== 0) {
+    throw new Error(res.data.message || "와이파이 결제 실패");
+  }
+
   return res.data.data.tradeId;
 };

--- a/src/feature/payment/hooks/usePaymentModals.tsx
+++ b/src/feature/payment/hooks/usePaymentModals.tsx
@@ -4,7 +4,7 @@ import {
   PaymentCompleteModal,
 } from "@feature/payment/components";
 import { usePaymentStore } from "@feature/payment/stores/paymentStore";
-import { postDefaultTrade } from "@feature/payment/api/paymentRequest";
+import { postDefaultTrade, postWifiTrade } from "@feature/payment/api/paymentRequest";
 import { postScrapTrade } from "@feature/payment/api/paymentRequest";
 import { toast } from "react-toastify";
 
@@ -38,16 +38,13 @@ export default function UsePaymentModals() {
               if (info.badge === "일반 구매") {
                 // 일반 전체 구매 (분할 불가)
                 if (info.productId && info.mobileDataId) {
-                  const tradeId = await postDefaultTrade(
-                    info.productId,
-                    info.mobileDataId
-                  );
+                  const tradeId = await postDefaultTrade(info.productId, info.mobileDataId);
                   console.log("일반 구매 완료", tradeId);
                 } else {
                   throw new Error("상품 정보가 누락되었습니다.");
                 }
               } else if (info.badge === "분할 구매") {
-                console.log(info)
+                console.log(info);
                 // 분할 구매 (분할 가능 상품 일부 구매)
                 if (info.productId && info.mobileDataId && info.dataAmount) {
                   const tradeId = await postDefaultTrade(
@@ -71,6 +68,19 @@ export default function UsePaymentModals() {
                 } else {
                   throw new Error("자투리 구매 정보가 누락되었습니다.");
                 }
+              }
+            } else if (info.type === "wifi") {
+              // 와이파이 구매
+              if (info.productId && info.wifiId && info.startTime && info.endTime) {
+                const tradeId = await postWifiTrade(
+                  info.productId,
+                  info.wifiId,
+                  info.startTime,
+                  info.endTime
+                );
+                console.log("와이파이 구매 완료", tradeId);
+              } else {
+                throw new Error("구매 정보가 누락되었습니다.");
               }
             }
             setStep("complete");

--- a/src/feature/payment/hooks/useWifiPurchaseBuilder.ts
+++ b/src/feature/payment/hooks/useWifiPurchaseBuilder.ts
@@ -1,0 +1,22 @@
+import { formatToIsoDate } from "@/lib/time";
+import type { MapDetailItem } from "@/feature/map/types/mapType";
+import type { PaymentInfo } from "@/feature/payment/types/paymentTypes";
+
+export const buildWifiPaymentInfo = (
+  data: MapDetailItem,
+  startTime: string,
+  endTime: string
+): PaymentInfo => {
+  return {
+    type: "wifi",
+    title: data.place,
+    price: `${data.pricePer10min.toLocaleString()}원`,
+    seller: data.memberName,
+    location: data.address,
+    duration: `${startTime} ~ ${endTime}`,
+    productId: Number(data.productId),
+    wifiId: data.wifiId,
+    startTime: formatToIsoDate(startTime),
+    endTime: formatToIsoDate(endTime),
+  };
+};

--- a/src/feature/payment/types/paymentTypes.ts
+++ b/src/feature/payment/types/paymentTypes.ts
@@ -33,4 +33,9 @@ export interface PaymentInfo {
   totalAmount?: number;
   totalPrice?: number;
   combinations?: ScrapCombination[];
+
+  // 와이파이 구매용
+  startTime?: string;
+  endTime?: string;
+  wifiId?: number;
 }

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -107,6 +107,16 @@ export const parseHHMMToTime = (hhmm: string): Time => {
   };
 };
 
+export const formatTimeToHHMM = (time: {
+  hour: string | number;
+  minute: string | number;
+}): string => {
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  const hour = typeof time.hour === "string" ? parseInt(time.hour, 10) : time.hour;
+  const minute = typeof time.minute === "string" ? parseInt(time.minute, 10) : time.minute;
+  return `${pad(hour)}:${pad(minute)}`;
+};
+
 export const compareTimes = (a: Time, b: Time): number => {
   const toMinutes = (t: Time) => {
     let hour = parseInt(t.hour, 10);


### PR DESCRIPTION
## 📌 작업 개요

- 와이파이 상품 결제 로직 구현 (`usePaymentModals.tsx`)
  - `postWifiTrade` API 연동
  - `productId`, `wifiId`, `startTime`, `endTime` 기반 결제 요청
 
- 구매 정보 구조 설정 (`buildWifiPaymentInfo`)
  - 시간 포맷을 ISO 문자열로 변환하여 전달
  - `MapDetailItem`에 `wifiId(itemId)` 포함
 
- `useMapDetailData` 훅에서 `itemId` → `wifiId`로 매핑 및 타입 수정

## ✨ 기타 참고 사항


https://github.com/user-attachments/assets/9cf0e398-2c3b-4469-aa74-c0f73051eeb1


- 시간 포맷: `"오전 9:00"` 등 → `"2025-07-27T09:00:00"` 형태로 변환

- 기존 결제 로직에 와이파이 구매 로직을 추가하는 방식으로 구현하였습니다. 추후 리팩토링이 필요해 보입니다.

## 🔗 관련 이슈

- close #137 

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
