### PR TITLE
[DP-195] feat: 채팅방 상단 옵션 메뉴 및 프로필 보기 연동

### DIFF
--- a/src/app/map/review/layout.tsx
+++ b/src/app/map/review/layout.tsx
@@ -1,5 +1,15 @@
 import { ReactNode, Suspense } from "react";
+import SharedHeader from "@components/common/header/SharedHeader";
+import BottomNavigation from "@components/common/navigation/BottomNavigation";
 
 export default function ReviewLayout({ children }: { children: ReactNode }) {
-  return <Suspense>{children}</Suspense>;
+  return (
+    <div className="relative h-[100dvh] w-full">
+      <SharedHeader />
+      <div className="flex-1 w-full max-w-4xl p-6">
+        <Suspense>{children}</Suspense>
+      </div>
+      <BottomNavigation />
+    </div>
+  );
 }

--- a/src/components/common/dropdown/dropdownConfig.ts
+++ b/src/components/common/dropdown/dropdownConfig.ts
@@ -43,11 +43,11 @@ export const createDataSortOptions = (onSelect: (label: string) => void): Dropdo
   },
 ];
 
-export const chatMenuOptions = (onReport: () => void): DropdownOption[] => [
+export const chatMenuOptions = (onReport: () => void, senderId?: number): DropdownOption[] => [
   {
     label: "프로필 보기",
     icon: User,
-    action: { type: "link", href: "/user/profile" },
+    action: { type: "link", href: senderId ? `/map/review?memberId=${senderId}` : "/map/review" },
   },
   {
     label: "신고하기",

--- a/src/feature/chat/components/sections/list/ChatItem.tsx
+++ b/src/feature/chat/components/sections/list/ChatItem.tsx
@@ -1,51 +1,70 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import AvatarIcon from "@/components/common/AvatarIcon";
 
 export interface ChatItemProps {
   chatRoomId: string;
   name: string;
-  timeAgo: string;
+  updatedAt: string;
   unreadCount?: number;
   avatarUrl?: string;
   productId: number;
   place?: string;
   pricePer10min?: number;
+  senderId?: number;
 }
 
 export default function ChatItem({
   chatRoomId,
   name,
-  timeAgo,
+  updatedAt,
   unreadCount = 0,
   avatarUrl,
   productId,
   place,
   pricePer10min,
+  senderId,
 }: ChatItemProps) {
+  const router = useRouter();
+
+  const handleAvatarClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (senderId) {
+      router.push(`/map/review?memberId=${senderId}`);
+    } else {
+      router.push("/map/review");
+    }
+  };
   return (
-    <Link href={`/chat/${chatRoomId}?productId=${productId}`} className="block">
-      <div className="cursor-pointer flex justify-between items-center gap-12">
-        <div className="flex items-center gap-12">
+    <div className="flex justify-between items-center gap-12 p-8 rounded-8 hover:bg-gray-50 transition-colors border-b border-gray-200">
+      <div className="flex items-center gap-12 flex-1">
+        <button onClick={handleAvatarClick} className="cursor-pointer">
           <AvatarIcon avatar={avatarUrl} size="medium" />
-          <div className="flex flex-col gap-2">
+        </button>
+        <Link href={`/chat/${chatRoomId}?productId=${productId}`} className="flex-1">
+          <div className="flex flex-col gap-2 cursor-pointer">
             <span className="body-sm text-black">{name}</span>
-            <span className="body-sm text-gray-800">{place}</span>
-            <span className="body-sm text-gray-800">
-              {pricePer10min ? `${pricePer10min}원/10분` : ""}
-            </span>
+            <div className="flex flex-col gap-2">
+              <span className="body-sm text-gray-800">{place}</span>
+              <span className="body-sm text-gray-800">
+                {pricePer10min ? `${pricePer10min}원/10분` : ""}
+              </span>
+            </div>
           </div>
-        </div>
-        <div className="flex flex-col items-end gap-2">
-          <span className="caption-lg text-gray-500">{timeAgo}</span>
+        </Link>
+      </div>
+      <Link href={`/chat/${chatRoomId}?productId=${productId}`}>
+        <div className="flex flex-col items-end gap-2 cursor-pointer">
+          <span className="caption-lg text-gray-500">{updatedAt}</span>
           {unreadCount > 0 && (
             <div className="w-20 h-20 rounded-full bg-primary text-white caption-md flex items-center justify-center">
               {unreadCount}
             </div>
           )}
         </div>
-      </div>
-    </Link>
+      </Link>
+    </div>
   );
 }

--- a/src/feature/chat/components/sections/list/ChatItem.tsx
+++ b/src/feature/chat/components/sections/list/ChatItem.tsx
@@ -14,6 +14,7 @@ export interface ChatItemProps {
   place?: string;
   pricePer10min?: number;
   senderId?: number;
+  lastMessage?: string;
 }
 
 export default function ChatItem({
@@ -24,8 +25,8 @@ export default function ChatItem({
   avatarUrl,
   productId,
   place,
-  pricePer10min,
   senderId,
+  lastMessage,
 }: ChatItemProps) {
   const router = useRouter();
 
@@ -38,7 +39,7 @@ export default function ChatItem({
     }
   };
   return (
-    <div className="flex justify-between items-center gap-12 p-8 rounded-8 hover:bg-gray-50 transition-colors border-b border-gray-200">
+    <div className="flex justify-between items-start gap-12 py-12 rounded-8 hover:bg-gray-50 transition-colors">
       <div className="flex items-center gap-12 flex-1">
         <button onClick={handleAvatarClick} className="cursor-pointer">
           <AvatarIcon avatar={avatarUrl} size="medium" />
@@ -48,15 +49,13 @@ export default function ChatItem({
             <span className="body-sm text-black">{name}</span>
             <div className="flex flex-col gap-2">
               <span className="body-sm text-gray-800">{place}</span>
-              <span className="body-sm text-gray-800">
-                {pricePer10min ? `${pricePer10min}원/10분` : ""}
-              </span>
+              <span className="body-sm text-gray-600">{lastMessage}</span>
             </div>
           </div>
         </Link>
       </div>
       <Link href={`/chat/${chatRoomId}?productId=${productId}`}>
-        <div className="flex flex-col items-end gap-2 cursor-pointer">
+        <div className="flex flex-row items-center gap-2 cursor-pointer">
           <span className="caption-lg text-gray-500">{updatedAt}</span>
           {unreadCount > 0 && (
             <div className="w-20 h-20 rounded-full bg-primary text-white caption-md flex items-center justify-center">

--- a/src/feature/chat/components/sections/list/ChatList.tsx
+++ b/src/feature/chat/components/sections/list/ChatList.tsx
@@ -19,8 +19,16 @@ export default function ChatList() {
       try {
         const apiList = await getChatRoomList(10, selectedFilter);
 
+        // 메시지가 있는 채팅방만 필터링
+        const filteredApiList = apiList.filter(
+          (item: ApiChatRoom) => item.lastMessage && item.lastMessage.trim() !== ""
+        );
+
         // 상품 정보 가져오기
-        const uniqueProductIds = [...new Set(apiList.map((item: ApiChatRoom) => item.productId))];
+        const uniqueProductIds = [
+          ...new Set(filteredApiList.map((item: ApiChatRoom) => item.productId)),
+        ];
+
         const productDetailsMap: Record<
           number,
           { title: string; price: number; memberId: number; memberName: string }
@@ -42,7 +50,7 @@ export default function ChatList() {
           }
         }
 
-        const chatList = apiList.map((item: ApiChatRoom) => {
+        const chatList = filteredApiList.map((item: ApiChatRoom) => {
           const productDetail = productDetailsMap[item.productId];
           return {
             chatRoomId: item.chatRoomId,
@@ -55,13 +63,13 @@ export default function ChatList() {
             senderName: item.senderName,
             avatarUrl: item.senderProfileImageUrl || "c",
             senderId: item.senderId,
+            lastMessage: item.lastMessage || "",
           };
         });
 
-        console.log("최종 chatList 상태:", chatList);
         setChatList(chatList);
       } catch (e) {
-        console.error(e);
+        console.error("채팅방 목록 가져오기 실패:", e);
       }
     }
     fetchChatRooms();
@@ -100,19 +108,24 @@ export default function ChatList() {
         className="overflow-y-auto overflow-x-hidden scrollbar-track-transparent"
         style={{ height: "calc(-108px + 100vh)" }}
       >
-        <div className="space-y-24 py-24 mb-56">
-          {chatList.map((chat) => (
-            <ChatItem
-              key={chat.chatRoomId}
-              chatRoomId={String(chat.chatRoomId)}
-              name={chat.name}
-              updatedAt={formatRelativeTime(chat.updatedAt)}
-              productId={chat.productId}
-              place={chat.title}
-              pricePer10min={chat.price}
-              avatarUrl={chat.avatarUrl}
-              senderId={chat.senderId}
-            />
+        <div className="py-24 mb-56">
+          {chatList.map((chat, index) => (
+            <div key={chat.chatRoomId}>
+              <ChatItem
+                chatRoomId={String(chat.chatRoomId)}
+                name={chat.name}
+                updatedAt={formatRelativeTime(chat.updatedAt)}
+                productId={chat.productId}
+                place={chat.title}
+                pricePer10min={chat.price}
+                avatarUrl={chat.avatarUrl}
+                senderId={chat.senderId}
+                lastMessage={chat.lastMessage}
+              />
+              {index < chatList.length - 1 && (
+                <div className="border-b border-gray-200 mx-24"></div>
+              )}
+            </div>
           ))}
         </div>
       </div>

--- a/src/feature/chat/components/sections/list/ChatList.tsx
+++ b/src/feature/chat/components/sections/list/ChatList.tsx
@@ -1,23 +1,17 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { toast } from "react-toastify";
-import { formatRelativeTime } from "@/lib/time";
 import { useChatStore } from "@feature/chat/stores/useChatStore";
 import ChatItem from "@feature/chat/components/sections/list/ChatItem";
 import { getChatRoomList } from "@feature/chat/api/chatRoomRequest";
 import { getMapDetailById } from "@feature/map/api/getMapDetailById";
 import { ApiChatRoom } from "@feature/chat/types/chatType";
 import { ButtonComponent } from "@/components/common/button/ButtonComponent";
-import { useProfileStore } from "@/stores/useProfileStore";
+import { formatRelativeTime } from "@/lib/time";
 
 export default function ChatList() {
   const chatList = useChatStore((state) => state.chatList);
   const setChatList = useChatStore((state) => state.setChatList);
-  const myUserId = useProfileStore((state) => state.id);
-  const [productDetails, setProductDetails] = useState<
-    Record<number, { title: string; price: number; memberId: number; memberName: string }>
-  >({});
   const [selectedFilter, setSelectedFilter] = useState<"ALL" | "BUYER" | "SELLER">("ALL");
 
   useEffect(() => {
@@ -34,37 +28,39 @@ export default function ChatList() {
 
         for (const productId of uniqueProductIds) {
           try {
-            const productData = await getMapDetailById(String(productId));
-            productDetailsMap[productId as number] = {
-              title: productData.title,
-              price: productData.price,
-              memberId: productData.memberId,
-              memberName: productData.memberName,
-            };
+            if (!productDetailsMap[productId as number]) {
+              const productData = await getMapDetailById(String(productId));
+              productDetailsMap[productId as number] = {
+                title: productData.title,
+                price: productData.price,
+                memberId: productData.memberId,
+                memberName: productData.memberName,
+              };
+            }
           } catch (error) {
             console.error(`상품 ${productId} 정보 가져오기 실패:`, error);
           }
         }
 
-        setProductDetails(productDetailsMap);
-
         const chatList = apiList.map((item: ApiChatRoom) => {
           const productDetail = productDetailsMap[item.productId];
-
-          const senderName =
-            productDetail?.memberId === myUserId ? "구매자" : productDetail?.memberName || "상대방";
-
           return {
             chatRoomId: item.chatRoomId,
-            name: senderName,
-            updatedAt: item.createdAt,
+            itemId: item.itemId,
+            name: item.senderName,
+            title: productDetail?.title || "",
+            price: productDetail?.price || 0,
+            updatedAt: item.lastMessageAt,
             productId: item.productId,
+            senderName: item.senderName,
+            avatarUrl: item.senderProfileImageUrl || "c",
+            senderId: item.senderId,
           };
         });
 
+        console.log("최종 chatList 상태:", chatList);
         setChatList(chatList);
       } catch (e) {
-        toast.error("채팅방 조회 중 오류가 발생했습니다.");
         console.error(e);
       }
     }
@@ -73,27 +69,30 @@ export default function ChatList() {
 
   return (
     <div className="flex flex-col px-24 pt-20">
-      <div className="flex gap-12">
+      <div className="flex gap-8">
         <ButtonComponent
-          variant={selectedFilter === "ALL" ? "primary" : "outlinePrimary"}
+          variant={selectedFilter === "ALL" ? "floatingPrimary" : "floatingOutline"}
           size="sm"
+          className="w-[50px]"
           onClick={() => setSelectedFilter("ALL")}
         >
           전체
         </ButtonComponent>
         <ButtonComponent
-          variant={selectedFilter === "BUYER" ? "primary" : "outlinePrimary"}
+          variant={selectedFilter === "SELLER" ? "floatingPrimary" : "floatingOutline"}
           size="sm"
-          onClick={() => setSelectedFilter("BUYER")}
-        >
-          구매
-        </ButtonComponent>
-        <ButtonComponent
-          variant={selectedFilter === "SELLER" ? "primary" : "outlinePrimary"}
-          size="sm"
+          className="w-[50px]"
           onClick={() => setSelectedFilter("SELLER")}
         >
           판매
+        </ButtonComponent>
+        <ButtonComponent
+          variant={selectedFilter === "BUYER" ? "floatingPrimary" : "floatingOutline"}
+          size="sm"
+          className="w-[50px]"
+          onClick={() => setSelectedFilter("BUYER")}
+        >
+          구매
         </ButtonComponent>
       </div>
 
@@ -107,11 +106,12 @@ export default function ChatList() {
               key={chat.chatRoomId}
               chatRoomId={String(chat.chatRoomId)}
               name={chat.name}
-              timeAgo={formatRelativeTime(chat.updatedAt)}
+              updatedAt={formatRelativeTime(chat.updatedAt)}
               productId={chat.productId}
-              place={productDetails[chat.productId]?.title}
-              pricePer10min={productDetails[chat.productId]?.price}
+              place={chat.title}
+              pricePer10min={chat.price}
               avatarUrl={chat.avatarUrl}
+              senderId={chat.senderId}
             />
           ))}
         </div>

--- a/src/feature/chat/components/sections/room/ChatBubble.tsx
+++ b/src/feature/chat/components/sections/room/ChatBubble.tsx
@@ -1,15 +1,17 @@
 import { formatTimeToAmPm } from "@/lib/time";
 import type { ChatSocketMessage } from "@/feature/chat/types/chatType";
 import AvatarIcon from "@/components/common/AvatarIcon";
+import Link from "next/link";
 
 import { cn } from "@/lib/utils";
 
 interface ChatBubbleProps {
   message: ChatSocketMessage;
   avatarUrl?: string;
+  senderId?: number;
 }
 
-export default function ChatBubble({ message, avatarUrl }: ChatBubbleProps) {
+export default function ChatBubble({ message, avatarUrl, senderId }: ChatBubbleProps) {
   const isMine = message.isMine;
   const timeText = formatTimeToAmPm(message.createdAt);
 
@@ -21,7 +23,14 @@ export default function ChatBubble({ message, avatarUrl }: ChatBubbleProps) {
 
   return (
     <div className={cn("flex items-end gap-2", isMine ? "justify-end" : "justify-start")}>
-      {!isMine && <AvatarIcon avatar={avatarUrl} size="small" />}
+      {!isMine && (
+        <Link
+          href={senderId ? `/map/review?memberId=${senderId}` : "/map/review"}
+          className="cursor-pointer"
+        >
+          <AvatarIcon avatar={avatarUrl} size="small" />
+        </Link>
+      )}
 
       {isMine ? (
         <div className="flex flex-row-reverse items-end gap-1">

--- a/src/feature/chat/components/sections/room/ChatPostCard.tsx
+++ b/src/feature/chat/components/sections/room/ChatPostCard.tsx
@@ -1,18 +1,20 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 
 interface ChatPostCardProps {
   title: string;
   pricePer10min?: number;
+  productId?: number;
 }
 
-export default function ChatPostCard({ title, pricePer10min }: ChatPostCardProps) {
+export default function ChatPostCard({ title, pricePer10min, productId }: ChatPostCardProps) {
   const match = title.match(/(\d+)GB/);
   const imageFile = match ? `/${match[1]}.png` : "/dpd-main-logo.png";
 
-  return (
-    <div className="flex border border-primary-200 rounded-20 h-64 px-16 py-8 bg-white">
+  const cardContent = (
+    <div className="flex border border-primary-200 rounded-20 h-64 px-16 py-8 bg-white cursor-pointer hover:bg-gray-50 transition-colors">
       <Image
         src={imageFile}
         alt={`${match?.[1]}GB 이미지`}
@@ -28,4 +30,10 @@ export default function ChatPostCard({ title, pricePer10min }: ChatPostCardProps
       </div>
     </div>
   );
+
+  if (productId) {
+    return <Link href={`/map/${productId}`}>{cardContent}</Link>;
+  }
+
+  return cardContent;
 }

--- a/src/feature/chat/components/sections/room/ChatRoomContent.tsx
+++ b/src/feature/chat/components/sections/room/ChatRoomContent.tsx
@@ -13,7 +13,6 @@ import { getChatHistory } from "@feature/chat/api/getChatHistory";
 import ChatRoomHeader from "@feature/chat/components/sections/room/ChatRoomHeader";
 import ReportModal from "@/components/common/modal/ReportModal";
 import { getMapDetailById } from "@feature/map/api/getMapDetailById";
-import { useProfileStore } from "@stores/useProfileStore";
 
 interface ChatRoomContentProps {
   chatRoomId: number;
@@ -38,7 +37,6 @@ export default function ChatRoomContent({ chatRoomId, productId }: ChatRoomConte
   const [oldestMessageId, setOldestMessageId] = useState<number | undefined>(undefined);
   const clientRef = useRef<Client | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const myUserId = useProfileStore((state) => state.id);
 
   // 상품 정보 가져오기
   useEffect(() => {
@@ -83,14 +81,12 @@ export default function ChatRoomContent({ chatRoomId, productId }: ChatRoomConte
     // 웹소켓 연결
     clientRef.current = createStompClient(chatRoomId, (msg: ChatSocketMessage) => {
       const data = typeof msg === "string" ? JSON.parse(msg) : msg;
-      console.log("서버에서 받은 메시지:", data);
       const incomingMessage: ChatSocketMessage = {
         chatMessageId: data.chatMessageId,
         isMine: data.isMine,
         message: data.message,
         createdAt: data.createdAt,
       };
-      console.log("변환된 메시지:", incomingMessage);
       // 중복 방지 로직
       setMessages((prev) => {
         if (prev.some((m) => m.chatMessageId === incomingMessage.chatMessageId)) {
@@ -171,7 +167,7 @@ export default function ChatRoomContent({ chatRoomId, productId }: ChatRoomConte
 
   const groupedMessages = groupMessagesByDate(sortedMessages);
 
-  const senderName = product?.memberId === myUserId ? "구매자" : product?.memberName || "상대방";
+  const senderName = product?.memberName || "상대방";
 
   return (
     <div className="flex flex-col h-screen">

--- a/src/feature/chat/components/sections/room/ChatRoomContent.tsx
+++ b/src/feature/chat/components/sections/room/ChatRoomContent.tsx
@@ -171,17 +171,23 @@ export default function ChatRoomContent({ chatRoomId, productId }: ChatRoomConte
 
   const groupedMessages = groupMessagesByDate(sortedMessages);
 
-  // 백엔드에서 senderName이 상대방 이름으로 수정될 예정
-  // 현재는 임시로 product 정보를 사용
   const senderName = product?.memberId === myUserId ? "구매자" : product?.memberName || "상대방";
 
   return (
     <div className="flex flex-col h-screen">
-      <ChatRoomHeader senderName={senderName} onReport={() => setIsReportOpen(true)} />
+      <ChatRoomHeader
+        senderName={senderName}
+        onReport={() => setIsReportOpen(true)}
+        senderId={product?.memberId}
+      />
 
       {product && (
         <div className="px-24 mt-24">
-          <ChatPostCard title={product.title} pricePer10min={product.pricePer10min} />
+          <ChatPostCard
+            title={product.title}
+            pricePer10min={product.pricePer10min}
+            productId={product.productId}
+          />
         </div>
       )}
 
@@ -197,7 +203,11 @@ export default function ChatRoomContent({ chatRoomId, productId }: ChatRoomConte
             </div>
             <div className="space-y-24">
               {group.messages.map((message) => (
-                <ChatBubble key={message.chatMessageId} message={message} />
+                <ChatBubble
+                  key={message.chatMessageId}
+                  message={message}
+                  senderId={product?.memberId}
+                />
               ))}
             </div>
           </div>

--- a/src/feature/chat/components/sections/room/ChatRoomHeader.tsx
+++ b/src/feature/chat/components/sections/room/ChatRoomHeader.tsx
@@ -8,9 +8,11 @@ import { chatMenuOptions } from "@/components/common/dropdown/dropdownConfig";
 export default function ChatRoomHeader({
   senderName,
   onReport,
+  senderId,
 }: {
   senderName: string;
   onReport: () => void;
+  senderId?: number;
 }) {
   const router = useRouter();
 
@@ -28,7 +30,7 @@ export default function ChatRoomHeader({
         <h1 className="title-sm font-semibold text-gray-900">{senderName}</h1>
       </div>
 
-      <UserDropdownMenu options={chatMenuOptions(handleReport)}>
+      <UserDropdownMenu options={chatMenuOptions(handleReport, senderId)}>
         <button className="p-1">
           <MoreVertical className="w-5 h-5" />
         </button>

--- a/src/feature/chat/stores/useChatStore.ts
+++ b/src/feature/chat/stores/useChatStore.ts
@@ -11,6 +11,7 @@ export interface ChatRoomPreview {
   senderName: string;
   avatarUrl: string;
   senderId: number;
+  lastMessage?: string;
 }
 
 interface ChatStore {

--- a/src/feature/chat/stores/useChatStore.ts
+++ b/src/feature/chat/stores/useChatStore.ts
@@ -10,6 +10,7 @@ export interface ChatRoomPreview {
   productId: number;
   senderName: string;
   avatarUrl: string;
+  senderId: number;
 }
 
 interface ChatStore {

--- a/src/feature/chat/types/chatType.ts
+++ b/src/feature/chat/types/chatType.ts
@@ -1,6 +1,7 @@
 export type ApiChatRoom = {
   chatRoomId: number;
   lastMessageAt: string;
+  lastMessage?: string;
   senderId: number;
   senderName: string;
   senderProfileImageUrl: string;

--- a/src/feature/chat/types/chatType.ts
+++ b/src/feature/chat/types/chatType.ts
@@ -1,9 +1,9 @@
 export type ApiChatRoom = {
   chatRoomId: number;
-  createdAt: string;
-  lastMessageAt: string | null;
+  lastMessageAt: string;
   senderId: number;
   senderName: string;
+  senderProfileImageUrl: string;
   productId: number;
   itemId: number;
   itemType: string;

--- a/src/feature/map/components/pages/ReviewRegistPage.tsx
+++ b/src/feature/map/components/pages/ReviewRegistPage.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import ReviewBottomSheet from "@feature/map/components/sections/review/ReviewBottomSheet";
+import { useSearchParams } from "next/navigation";
 import { useState } from "react";
 
 export default function ReviewRegistPageContent() {
-  // const tradeId = Number(params.get("tradeId"));
-  const tradeId = 141;
+  const params = useSearchParams();
+  const tradeId = Number(params.get("tradeId"));
   const [isOpen, setIsOpen] = useState(true);
   if (!tradeId || isNaN(tradeId)) {
     return <div>잘못된 접근입니다. tradeId가 없습니다.</div>;

--- a/src/feature/map/components/sections/review/ReviewBottomSheet.tsx
+++ b/src/feature/map/components/sections/review/ReviewBottomSheet.tsx
@@ -42,7 +42,7 @@ export default function ReviewBottomSheet({ isOpen, onClose, tradeId }: ReviewBo
   };
 
   return (
-    <BaseBottomSheet isOpen={isOpen} onClose={handleClose} variant="hybrid" snapHeight={320}>
+    <BaseBottomSheet isOpen={isOpen} onClose={handleClose} variant="hybrid" snapHeight={250}>
       <div className="flex flex-col gap-8 px-24 py-24">
         <div className="flex justify-between items-center">
           <span className="h3 text-black">거래 후기 남기기</span>


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->

- 채팅방 상단 옵션 메뉴에 "프로필 보기", "신고하기" 추가 및 연동
- 상대방 아바타 클릭 시 해당 회원의 리뷰 프로필 페이지(/map/review?memberId=...)로 이동 가능
- 채팅방 목록 및 버블에서도 아바타 클릭 시 상대방 기본정보 페이지로 이동되도록 처리
- ChatPostCard에서 해당 상품 상세페이지로 이동하도록 적용
- BottomSheet 높이 조정
- lastMessage 기능 구현

## ✨ 테스트 화면
<p align="center">
  <img src="https://github.com/user-attachments/assets/319d51a8-4216-4935-a1ec-194c66e6c28c" width="30%" />
  <img src="https://github.com/user-attachments/assets/e95bef83-beee-479a-81b9-fce89caeaf2b" width="30%" />
  <img src="https://github.com/user-attachments/assets/70f9397f-1f85-469d-8a22-e6548cb5a9e1" width="30%" />
</p>

<img width="284" height="663" alt="image" src="https://github.com/user-attachments/assets/2bbdee01-3fa8-4bfd-ac80-d39109fd8194" />


## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #149 

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
