### PR TITLE
[DP-209] feat: 웹소켓 전역 연결 및 채팅방 구독 구조 개선 #165

### DIFF
--- a/src/components/common/ProviderWrapper.tsx
+++ b/src/components/common/ProviderWrapper.tsx
@@ -1,11 +1,10 @@
 "use client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { PropsWithChildren } from "react";
+import { useWebSocketConnection } from "@/hooks/useWebSocketConnection";
 
 export default function ProviderWrapper({ children }: PropsWithChildren) {
-  return (
-    <QueryClientProvider client={new QueryClient()}>
-      {children}
-    </QueryClientProvider>
-  );
+  useWebSocketConnection();
+
+  return <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>;
 }

--- a/src/feature/chat/components/sections/list/ChatItem.tsx
+++ b/src/feature/chat/components/sections/list/ChatItem.tsx
@@ -44,7 +44,12 @@ export default function ChatItem({
         <button onClick={handleAvatarClick} className="cursor-pointer">
           <AvatarIcon avatar={avatarUrl} size="medium" />
         </button>
-        <Link href={`/chat/${chatRoomId}?productId=${productId}`} className="flex-1">
+        <Link
+          href={`/chat/${chatRoomId}?productId=${productId}&senderName=${encodeURIComponent(
+            name
+          )}&senderId=${senderId || ""}`}
+          className="flex-1"
+        >
           <div className="flex flex-col gap-2 cursor-pointer">
             <span className="body-sm text-black">{name}</span>
             <div className="flex flex-col gap-2">

--- a/src/feature/chat/types/chatType.ts
+++ b/src/feature/chat/types/chatType.ts
@@ -21,6 +21,7 @@ export interface ChatSocketMessage {
   message: string;
   createdAt: string;
   isMine: boolean;
+  senderName?: string;
 }
 
 export interface CursorPageResponse<T> {

--- a/src/hooks/useWebSocketConnection.ts
+++ b/src/hooks/useWebSocketConnection.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { useWebSocketStore } from "@/stores/useWebSocketStore";
+import { useProfileStore } from "@/stores/useProfileStore";
+
+export const useWebSocketConnection = () => {
+  const { connect, disconnect, isConnected } = useWebSocketStore();
+  const { id: userId } = useProfileStore();
+
+  useEffect(() => {
+    if (userId && !isConnected) {
+      connect().catch((error) => {
+        console.error("WebSocket 연결 실패:", error);
+      });
+    }
+
+    // 컴포넌트 언마운트 시 연결 해제 (앱 종료 시)
+    return () => {
+      // 앱 전체가 종료되는 경우에만 연결 해제, 개별 페이지 이동 시에는 연결 유지
+    };
+  }, [userId, isConnected, connect]);
+
+  const disconnectOnLogout = () => {
+    disconnect();
+  };
+
+  return {
+    isConnected,
+    disconnectOnLogout,
+  };
+};


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 웹소켓 연결 방식을 개선하여 로그인 시 단일 WebSocket 연결을 유지하고, 채팅방 입장 시 필요한 방에만 구독하도록 구조 변경
- 기존 채팅방 입장 시마다 생성되던 WebSocket 연결을 앱 전역에서 1회만 연결하고, 채팅방 단위로 구독(subscribe)/구독해제(unsubscribe) 처리하는 방식으로 리팩토링

## 📌 주요 변경 사항

**- 전역 WebSocket 관리 zustand store 구현**
- WebSocket 클라이언트 전역 관리
- 채팅방 별 구독 정보 Map<chatRoomId, callback>으로 저장
- subscribe/unsubscribe/sendMessage/연결/해제 기능 포함

**- 전역 연결 훅 추가**
- 로그인 시 자동 websocket 연결
- providerWrapper에서 전역 사용하도록 적용

**- 채팅방 내 구독 처리 방식 변경**
- 기존의 createStompClient → zustand 기반 store의 subscribe, unsubscribe, sendMessage 사용하도록 변경
- 채팅방 구독 시 chatRoomId 기반 메시지 처리 콜백 등록
- searchParams에서 senderName, senderId 전달받아 상대방 정보 렌더링 정확도 개선


## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 현재 disconnect()는 로그인 해제 시점에만 수동으로 호출되도록 구성되어 있습니다.
- 현재 주석처리는 추후 한번에 삭제할 예정입니다.

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #165 

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
