### PR TITLE
[DP-209] 와이파이 구매 시간 수정 #175

### DIFF
--- a/src/app/(feature)/layout.tsx
+++ b/src/app/(feature)/layout.tsx
@@ -4,9 +4,9 @@ import { ReactNode, Suspense } from "react";
 
 export default function FeatureLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="flex flex-col justify-center items-center w-[100dvw] lg:w-[375px] h-[100dvh] box-border">
+    <div className="relative w-[100dvw] lg:w-[375px] h-[100dvh] mx-auto bg-white overflow-hidden">
       <SharedHeader />
-      <main className="relative antialiased flex-1 min-h-[calc(100dvh-112px)] w-full overflow-y-visible overflow-x-clip bg-white">
+      <main className="pt-[60px] pb-[64px] h-full overflow-y-auto antialiased">
         <Suspense>{children}</Suspense>
       </main>
       <BottomNavigation />

--- a/src/components/common/header/SharedHeader.tsx
+++ b/src/components/common/header/SharedHeader.tsx
@@ -23,7 +23,7 @@ export default function SharedHeader() {
     <header className={clsx(isDataPage && "bg-primary2")}>
       <div
         className={clsx(
-          "bg-white border-none overflow-x-clip sticky top-0 z-50 transition-opacity duration-300 shrink-0",
+          "fixed top-0 z-50 w-[100dvw] lg:w-[375px] mx-auto shadow-header bg-white",
           isDataPage && !isVisible && "opacity-0 pointer-events-none",
           "w-[100dvw] lg:w-[375px] mx-auto shadow-header",
           isChatRoom && "hidden"

--- a/src/components/common/input/InputComponent.tsx
+++ b/src/components/common/input/InputComponent.tsx
@@ -21,6 +21,7 @@ interface BaseProps {
   size?: InputSize;
   disabled?: boolean;
   required?: boolean;
+  step?: number;
 }
 
 // input 전용 props
@@ -55,6 +56,7 @@ const InputComponent = forwardRef<HTMLTextAreaElement | HTMLInputElement, InputC
       required = false,
       type = "text",
       rows = 3,
+      step = 100,
     },
     ref
   ) {
@@ -123,6 +125,7 @@ const InputComponent = forwardRef<HTMLTextAreaElement | HTMLInputElement, InputC
         onKeyDown={onKeyDown as React.KeyboardEventHandler<HTMLInputElement>}
         disabled={disabled}
         required={required}
+        step={type === "number" ? step : undefined}
         className={cn(inputRadius, inputSize, color, className)}
       />
     );

--- a/src/components/common/navigation/BottomNavigation.tsx
+++ b/src/components/common/navigation/BottomNavigation.tsx
@@ -13,7 +13,7 @@ export default function BottomNavigation() {
   return (
     <div
       className={cn(
-        "bottom-0 z-50 bg-white border-none overflow-x-clip w-[100dvw] lg:w-[375px] shrink-0",
+        "fixed bottom-0 z-50 w-[100dvw] lg:w-[375px] mx-auto shadow-nav bg-white",
         isHidden && "hidden"
       )}
     >

--- a/src/components/common/topsheet/WifiTopSheetContent.tsx
+++ b/src/components/common/topsheet/WifiTopSheetContent.tsx
@@ -6,8 +6,9 @@ export function WifiTopSheetContent({ data, expanded }: { data: WifiData; expand
     <>
       <div className="space-y-8">
         <BadgeComponent variant="meta" size="md" className="bg-primary2 text-black">
-          와이파이
+          {data.open ? "운영 중" : "운영 예정"}
         </BadgeComponent>
+
         <h2 className="title-sm">{data.place}</h2>
         <p className="caption-md text-gray-500 max-w-[142px] break-words">{data.address}</p>
       </div>

--- a/src/components/common/topsheet/topSheet.types.ts
+++ b/src/components/common/topsheet/topSheet.types.ts
@@ -12,6 +12,7 @@ export interface PostData {
 }
 
 export interface WifiData {
+  open: boolean;
   imageUrl: string[];
   place: string;
   address: string;

--- a/src/feature/data/components/pages/DefaultTabContent.tsx
+++ b/src/feature/data/components/pages/DefaultTabContent.tsx
@@ -23,8 +23,6 @@ export default function DefaultTabContent({ isSheetOpen, onSearchClick }: Defaul
   const [sortLabel, setSortLabel] = useState("최신순");
   const { dataAmount, clearDataAmount } = useDataFilterStore();
 
-  console.log("sheet", isSheetOpen);
-
   const convertSortLabelToEnum = (
     label: string
   ): "RECENT" | "PRICE_ASC" | "AMOUNT_ASC" | "AMOUNT_DESC" => {

--- a/src/feature/map/api/mapRequest.ts
+++ b/src/feature/map/api/mapRequest.ts
@@ -22,8 +22,9 @@ interface WifiItemResponse {
   imageUrl: string | null;
   averageRate: number;
   distanceKm: number;
-  updatedAt: string;
   open: boolean;
+  openTime: string;
+  closeTime: string;
 }
 
 interface WifiRegisterRequest {
@@ -92,7 +93,8 @@ export async function getMapList({
       location: `${item.latitude},${item.longitude}`,
       score: item.averageRate,
       type: "와이파이",
-      updatedAt: new Date(item.updatedAt).toLocaleTimeString(),
+      openTime: new Date(item.openTime).toLocaleTimeString(),
+      closeTime: new Date(item.closeTime).toLocaleTimeString(),
       imageUrl: item.imageUrl ?? "",
     }));
 

--- a/src/feature/map/components/pages/MapDetailPage.tsx
+++ b/src/feature/map/components/pages/MapDetailPage.tsx
@@ -17,7 +17,6 @@ import { usePaymentStore } from "@feature/payment/stores/paymentStore";
 import clsx from "clsx";
 import { buildWifiPaymentInfo } from "@feature/payment/hooks/useWifiPurchaseBuilder";
 import UsePaymentModals from "@feature/payment/hooks/usePaymentModals";
-import dayjs from "dayjs";
 
 export default function MapDetailPage() {
   const router = useRouter();
@@ -78,22 +77,7 @@ export default function MapDetailPage() {
 
     setError(null);
 
-    const start = dayjs()
-      .hour(Number(startTime.hour))
-      .minute(Number(startTime.minute))
-      .second(0)
-      .millisecond(0)
-      .toISOString();
-
-    const end = dayjs()
-      .add(1, "day")
-      .hour(Number(endTime.hour))
-      .minute(Number(endTime.minute))
-      .second(0)
-      .millisecond(0)
-      .toISOString();
-
-    setInfo(buildWifiPaymentInfo(data, start, end));
+    setInfo(buildWifiPaymentInfo(data, startTime, endTime));
 
     // handlePurchase(startTime, endTime, () => {
     //   router.push("/data");
@@ -141,7 +125,7 @@ export default function MapDetailPage() {
             variant="primary"
             size="xl"
             onClick={onBuy}
-            disabled={!data.open || isOwner}
+            disabled={isOwner}
           >
             {isOwner ? "내 게시글입니다" : "구매하기"}
           </ButtonComponent>

--- a/src/feature/map/components/sections/product/MapItemContent.tsx
+++ b/src/feature/map/components/sections/product/MapItemContent.tsx
@@ -9,11 +9,9 @@ import { toast } from "react-toastify";
 import Image from "next/image";
 
 export default function MapItemCardContent({
-  data: { productId, address, price, score, title, type, updatedAt, open, imageUrl },
-  disableUseButton = false,
+  data: { productId, address, price, score, title, openTime, closeTime, open, imageUrl },
 }: ProductItemProps<MapType> & { disableUseButton?: boolean }) {
   const router = useRouter();
-  const isDisabled = disableUseButton || !open;
   const handleCreateChatRoom = useCallback(
     async (e: React.MouseEvent) => {
       e.stopPropagation();
@@ -60,7 +58,9 @@ export default function MapItemCardContent({
                 <Star className="fill-current" />
                 <span className="body-xs text-black ml-4">({score})</span>
               </div>
-              <span className="caption-lg text-gray-500">{updatedAt}</span>
+              <span className="caption-lg text-gray-500">
+                {openTime}~{closeTime}
+              </span>
             </div>
           </div>
           <span className="body-xxs text-gray-400 truncate max-w-[115px]">{address}</span>
@@ -70,10 +70,10 @@ export default function MapItemCardContent({
         <div className="flex flex-col items-end">
           <span
             className={`${
-              type === "와이파이" ? "bg-primary2 text-black" : "bg-secondary2 text-black"
+              open ? "bg-primary2 text-black" : "bg-secondary2 text-black"
             } body-xxs rounded-circle px-8 py-2 mb-4`}
           >
-            {type}
+            {open ? "운영 중" : "운영 예정"}
           </span>
           <span className="text-primary body-md">{price}</span>
           <span className="body-xs text-gray-700">10분당</span>
@@ -86,11 +86,8 @@ export default function MapItemCardContent({
           size="sm"
           variant="primary"
           className="flex-6"
-          disabled={isDisabled}
           onClick={() => {
-            if (!isDisabled) {
-              router.push(`/map/${productId}`);
-            }
+            router.push(`/map/${productId}`);
           }}
         >
           이용하기

--- a/src/feature/map/components/sections/product/TimeSelectorSection.tsx
+++ b/src/feature/map/components/sections/product/TimeSelectorSection.tsx
@@ -64,12 +64,14 @@ export default function TimeSelectorSection({
       <div className="flex items-center justify-between mb-4">
         <h3 className="title-md">이용할 시간</h3>
         {showEditButton && (
-          <div className="flex gap-6">
-            <ButtonComponent variant="outlineGray" size="sm" onClick={onDeleteClick}>
-              <Trash2 className="w-12 h-12 mr-2" />글 삭제하기
+          <div className="flex gap-4">
+            <ButtonComponent variant="outlineGray" size="xs" onClick={onDeleteClick}>
+              <Trash2 className="w-12 h-12 mr-2" />
+              삭제하기
             </ButtonComponent>
-            <ButtonComponent variant="outlineGray" size="sm" onClick={onEditClick}>
-              <Pencil className="w-12 h-12 mr-2" />글 수정하기
+            <ButtonComponent variant="outlineGray" size="xs" onClick={onEditClick}>
+              <Pencil className="w-12 h-12 mr-2" />
+              수정하기
             </ButtonComponent>
           </div>
         )}

--- a/src/feature/map/components/sections/regist/MapRegisterModal.tsx
+++ b/src/feature/map/components/sections/regist/MapRegisterModal.tsx
@@ -12,7 +12,7 @@ interface Props {
 export default function MapRegisterModal({ open, onClose }: Props) {
   return (
     <BaseModal isOpen={open} onClose={onClose}>
-      <ModalHeader title="등록 유형 선택" onClose={onClose} />
+      <ModalHeader title="새 게시글 등록" onClose={onClose} />
       <SelectTypeCard />
     </BaseModal>
   );

--- a/src/feature/map/components/sections/regist/SelectTypeCard.tsx
+++ b/src/feature/map/components/sections/regist/SelectTypeCard.tsx
@@ -2,10 +2,9 @@
 
 import { useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { WifiIcon, RouterIcon } from "lucide-react";
+import { WifiIcon } from "lucide-react";
 import InfoCard from "@components/common/card/InfoCard";
 import SelectTypeContent from "@/feature/map/components/sections/regist/SelectTypeContent";
-import { cn } from "@/lib/utils";
 
 export default function SelectTypeCard() {
   const router = useRouter();
@@ -20,15 +19,6 @@ export default function SelectTypeCard() {
 
   return (
     <div className="flex flex-col gap-16">
-      {/* 핫스팟 등록 카드 (비활성화 상태) */}
-      <div className={cn("transition-opacity", "opacity-50 pointer-events-none")}>
-        <InfoCard handleClick={() => {}}>
-          <SelectTypeContent title="핫스팟 등록" description="준비 중입니다.">
-            <RouterIcon />
-          </SelectTypeContent>
-        </InfoCard>
-      </div>
-
       {/* 와이파이 등록 카드 */}
       <InfoCard handleClick={goToWifi}>
         <SelectTypeContent title="와이파이 등록" description="공공 와이파이를 등록하세요">

--- a/src/feature/map/components/sections/regist/TimeRangeField.tsx
+++ b/src/feature/map/components/sections/regist/TimeRangeField.tsx
@@ -10,6 +10,15 @@ interface Props {
 }
 
 export default function TimeRangeField({ form, updateForm, errors }: Props) {
+  const handleTimeChange =
+    (key: "startTime" | "endTime") =>
+    (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      let raw = e.target.value.replace(/[^0-9]/g, "").slice(0, 4);
+      if (raw.length >= 3) {
+        raw = `${raw.slice(0, 2)}:${raw.slice(2)}`;
+      }
+      updateForm(key, raw);
+    };
   return (
     <section className="mb-16">
       <label className="title-sm mb-12 block">이용 시간</label>
@@ -17,7 +26,7 @@ export default function TimeRangeField({ form, updateForm, errors }: Props) {
         <InputComponent
           placeholder="예: 09:00"
           value={form.startTime}
-          onChange={(e) => updateForm("startTime", e.target.value)}
+          onChange={handleTimeChange("startTime")}
           className={cn("px-3", errors.startTime && "border-primary border-[2px]")}
           radius="md"
           size="md"
@@ -26,7 +35,7 @@ export default function TimeRangeField({ form, updateForm, errors }: Props) {
         <InputComponent
           placeholder="예: 18:00"
           value={form.endTime}
-          onChange={(e) => updateForm("endTime", e.target.value)}
+          onChange={handleTimeChange("endTime")}
           className={cn("px-3", errors.endTime && "border-primary border-[2px]")}
           radius="md"
           size="md"

--- a/src/feature/map/hooks/useInteractiveMapMarker.ts
+++ b/src/feature/map/hooks/useInteractiveMapMarker.ts
@@ -91,4 +91,7 @@ export function useInteractiveMapMarker({
 
     onLocationSelect(lat, lng);
   }, [map, isEditMode, editData, onLocationSelect]);
+  return {
+    selectLocation: setMarkerWithInfo,
+  };
 }

--- a/src/feature/map/hooks/useMyLocation.ts
+++ b/src/feature/map/hooks/useMyLocation.ts
@@ -26,6 +26,7 @@ export function useMyLocation(map?: naver.maps.Map | null) {
               content:
                 '<div style="background:#e6007e;width:12px;height:12px;border-radius:9999px;"></div>',
             },
+            zIndex: 999,
           });
         }
       },

--- a/src/feature/map/hooks/useMyLocation.ts
+++ b/src/feature/map/hooks/useMyLocation.ts
@@ -27,6 +27,8 @@ export function useMyLocation(map?: naver.maps.Map | null) {
                 '<div style="background:#e6007e;width:12px;height:12px;border-radius:9999px;"></div>',
             },
             zIndex: 999,
+          }).addListener("click", () => {
+            window.naver.maps.Event.trigger(map, "click", { coord: latlng });
           });
         }
       },

--- a/src/feature/map/hooks/usePostWifiRegister.ts
+++ b/src/feature/map/hooks/usePostWifiRegister.ts
@@ -4,7 +4,7 @@ import { useSearchParams, useRouter } from "next/navigation";
 import { useMutation } from "@tanstack/react-query";
 import { postWifiRegister, putWifiUpdate } from "@/feature/map/api/mapRequest";
 import type { RegisterFormValues, RegisterFormData } from "@/feature/map/types/registerForm";
-import { formatToIsoDate, formatToIsoDatePlusOneYear } from "@lib/time";
+import { formatToIsoDate, formatToIsoDatePlusOneYear, parseHHMMToTime } from "@lib/time";
 
 interface UsePostWifiRegisterOptions {
   form: RegisterFormValues;
@@ -35,7 +35,7 @@ export const usePostWifiRegister = ({ form, onSuccess, onSubmit }: UsePostWifiRe
         price: parseInt(form.price, 10),
         latitude: parseFloat(lat),
         longitude: parseFloat(lng),
-        startTime: formatToIsoDate(form.startTime),
+        startTime: formatToIsoDate(parseHHMMToTime(form.startTime)),
         endTime: formatToIsoDatePlusOneYear(form.endTime),
         address,
         images: form.images ?? [],
@@ -49,6 +49,7 @@ export const usePostWifiRegister = ({ form, onSuccess, onSubmit }: UsePostWifiRe
       }
     },
     onSuccess: () => {
+      console.log(form);
       onSubmit?.({
         ...form,
         lat: parseFloat(lat!),

--- a/src/feature/map/hooks/usePostWifiRegister.ts
+++ b/src/feature/map/hooks/usePostWifiRegister.ts
@@ -49,7 +49,6 @@ export const usePostWifiRegister = ({ form, onSuccess, onSubmit }: UsePostWifiRe
       }
     },
     onSuccess: () => {
-      console.log(form);
       onSubmit?.({
         ...form,
         lat: parseFloat(lat!),

--- a/src/feature/map/types/mapType.ts
+++ b/src/feature/map/types/mapType.ts
@@ -4,7 +4,8 @@ export interface MapType {
   title: string;
   address: string;
   location: string;
-  updatedAt: string;
+  openTime: string;
+  closeTime: string;
   open: boolean;
   score: number;
   price: string;

--- a/src/feature/payment/api/paymentRequest.ts
+++ b/src/feature/payment/api/paymentRequest.ts
@@ -37,13 +37,13 @@ export const postWifiTrade = async (
   startTime: string,
   endTime: string
 ): Promise<number> => {
+  console.log(productId, wifiId, startTime, endTime);
   const res = await axios.post("/api/trades/wifi", {
     productId,
     wifiId,
     startTime,
     endTime,
   });
-
   if (res.data.code !== 0) {
     throw new Error(res.data.message || "와이파이 결제 실패");
   }

--- a/src/feature/payment/components/PaymentConfirmModal.tsx
+++ b/src/feature/payment/components/PaymentConfirmModal.tsx
@@ -3,6 +3,7 @@
 import BaseModal from "@/components/common/modal/BaseModal";
 import ModalHeader from "@/components/common/modal/ModalHeader";
 import { ButtonComponent } from "@/components/common/button/ButtonComponent";
+import { formatIsoToHHMM } from "@lib/time";
 
 interface PaymentConfirmModalProps {
   isOpen: boolean;
@@ -15,17 +16,12 @@ interface PaymentConfirmModalProps {
     buyerType?: "일반 구매" | "분할 구매" | "자투리 구매"; // 데이터만 해당
     seller?: string;
     location?: string; // 와이파이/핫스팟
-    duration?: string; // 와이파이/핫스팟
+    startTime?: string; // 와이파이/핫스팟
+    endTime?: string;
   };
 }
 
-const PaymentConfirmModal = ({
-  isOpen,
-  onClose,
-  onNext,
-  type,
-  info,
-}: PaymentConfirmModalProps) => {
+const PaymentConfirmModal = ({ isOpen, onClose, onNext, type, info }: PaymentConfirmModalProps) => {
   return (
     <BaseModal isOpen={isOpen} onClose={onClose}>
       <ModalHeader title="결제 확인" onClose={onClose} />
@@ -38,16 +34,20 @@ const PaymentConfirmModal = ({
 
         <div className="text-gray-600 body-sm space-y-4 mb-32 text-left">
           <p>📦 구매 물품: {info.title}</p>
-          {type === "data" && info.buyerType && (
-            <p>💳 구매 방식: {info.buyerType}</p>
-          )}
+          {type === "data" && info.buyerType && <p>💳 구매 방식: {info.buyerType}</p>}
           {info.seller && <p>👤 판매자: {info.seller}</p>}
           {info.location && <p>📍 위치: {info.location}</p>}
-          {info.duration && <p>⏱️ 이용 시간: {info.duration}</p>}
+          {info.startTime && info.endTime && (
+            <p>
+              ⏱️ 이용 시간: {formatIsoToHHMM(info.startTime)} ~ {formatIsoToHHMM(info.endTime)}
+            </p>
+          )}
           <p>💰 결제 가격: {info.price}</p>
         </div>
 
-        <ButtonComponent className="w-[278px]" onClick={onNext}>결제 계속하기</ButtonComponent>
+        <ButtonComponent className="w-[278px]" onClick={onNext}>
+          결제 계속하기
+        </ButtonComponent>
       </div>
     </BaseModal>
   );

--- a/src/feature/payment/hooks/usePaymentModals.tsx
+++ b/src/feature/payment/hooks/usePaymentModals.tsx
@@ -25,7 +25,8 @@ export default function UsePaymentModals() {
           buyerType: info.badge,
           seller: info.seller,
           location: info.location,
-          duration: info.duration,
+          startTime: info.startTime,
+          endTime: info.endTime,
         }}
       />
 

--- a/src/feature/payment/hooks/useWifiPurchaseBuilder.ts
+++ b/src/feature/payment/hooks/useWifiPurchaseBuilder.ts
@@ -1,11 +1,12 @@
-import { formatToIsoDate } from "@/lib/time";
+import { formatToIsoDate, formatToIsoDatePlusOneDay } from "@/lib/time";
 import type { MapDetailItem } from "@/feature/map/types/mapType";
 import type { PaymentInfo } from "@/feature/payment/types/paymentTypes";
+import { Time } from "@type/Time";
 
 export const buildWifiPaymentInfo = (
   data: MapDetailItem,
-  startTime: string,
-  endTime: string
+  startTime: Time,
+  endTime: Time
 ): PaymentInfo => {
   return {
     type: "wifi",
@@ -17,6 +18,6 @@ export const buildWifiPaymentInfo = (
     productId: Number(data.productId),
     wifiId: data.wifiId,
     startTime: formatToIsoDate(startTime),
-    endTime: formatToIsoDate(endTime),
+    endTime: formatToIsoDatePlusOneDay(endTime),
   };
 };

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -81,14 +81,40 @@ export const formatToIsoTime = (time: Time): string => {
   return now.toISOString();
 };
 
-export function formatToIsoDate(time: string): string {
+export function formatIsoToHHMM(isoString: string): string {
+  const date = new Date(isoString);
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${hours}:${minutes}`;
+}
+
+export function formatToIsoDate(time: Time): string {
   const now = new Date();
-  const [hour, minute] = time.split(":");
-  now.setHours(Number(hour));
-  now.setMinutes(Number(minute));
+  let hour = parseInt(time.hour, 10);
+  if (time.period === "PM" && hour !== 12) hour += 12;
+  if (time.period === "AM" && hour === 12) hour = 0;
+
+  now.setHours(hour);
+  now.setMinutes(parseInt(time.minute, 10));
   now.setSeconds(0);
   now.setMilliseconds(0);
   return now.toLocaleString("sv-SE").replace(" ", "T");
+}
+
+// 1일 추가 -> 백엔드 처리 후 삭제
+export function formatToIsoDatePlusOneDay(time: Time): string {
+  const now = new Date();
+  now.setDate(now.getDate() + 1);
+
+  let hour = parseInt(time.hour, 10);
+  if (time.period === "PM" && hour !== 12) hour += 12;
+  if (time.period === "AM" && hour === 12) hour = 0;
+
+  now.setHours(hour);
+  now.setMinutes(parseInt(time.minute, 10));
+  now.setSeconds(0);
+  now.setMilliseconds(0);
+  return now.toLocaleString("sv-SE").replace(" ", "T"); // 예: 2025-07-31T09:00:00
 }
 
 // 1년 추가 -> 백엔드 처리 후 삭제


### PR DESCRIPTION
## 📌 작업 개요

- 판매자 프로필 경로 수정
- 등록 버튼 클릭 시 중간 선택 없이 바로 등록 바텀시트 노출
- 와이파이 등록 시 내 위치 선택이 되지 않던 이슈 수정
- 운영시간과 무관하게 와이파이 구매 가능하도록 로직 수정 (미리 구매 가능)
- 구매 시간 전달 시 현재 시간 계산이 제대로 안 되던 문제 수정
- 와이파이 카드의 뱃지를 `운영 중 / 운영 예정`으로 변경
- 카드 내 글 등록 시간 → 실제 가게 운영 시간으로 변경
- 와이파이 등록 시 이용 시간 자동으로 추가되는 로직 보완
- 상대방 프로필 영역에 커서 스타일 추가 (hover 시 pointer)
- 등록 시 가격 입력값을 100 단위로 자동 반올림 처리
- 와이파이 글 수정/삭제 기능을 데이터 게시글과 동일한 구조로 통일

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->

<img width="871" height="709" alt="스크린샷 2025-07-30 151354" src="https://github.com/user-attachments/assets/205a0183-9ecc-4d07-8d23-4490e05f0b7f" />

백엔드에서 updatedAy -> startTime, endTime 으로 수정되면 카드에 운영시간이 뜨게 수정될 예정입니다.

## 🔗 관련 이슈

- close #175 

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
