### PR TITLE
[DP-236] fix: map페이지에서 본인 게시글일때 채팅과 구매 제한 #193

### DIFF
--- a/src/feature/map/components/pages/MapDetailPage.tsx
+++ b/src/feature/map/components/pages/MapDetailPage.tsx
@@ -13,6 +13,7 @@ import DeletePostModal from "@/feature/data/components/sections/modal/DeletePost
 import { isValidTimeRange, parseHHMMToTime, isTimeInRange } from "@/lib/time";
 import { useWifiPriceRecommendation } from "@/feature/map/hooks/useWifiPriceRecommendation";
 import { usePaymentStore } from "@feature/payment/stores/paymentStore";
+import { toast } from "react-toastify";
 
 import clsx from "clsx";
 import { buildWifiPaymentInfo } from "@feature/payment/hooks/useWifiPurchaseBuilder";
@@ -59,7 +60,10 @@ export default function MapDetailPage() {
   const maxTime = parseHHMMToTime(data.endTime);
 
   const onBuy = () => {
-    if (isOwner) return;
+    if (isOwner) {
+      toast.info("내 게시글입니다");
+      return;
+    }
 
     if (!isValidTimeRange(startTime, endTime)) {
       setError("종료 시간은 시작 시간보다 늦어야 합니다.");
@@ -117,17 +121,15 @@ export default function MapDetailPage() {
           />
         </div>
 
-        <SellerSection sellerId={data.memberId} productId={String(data.productId)} />
+        <SellerSection
+          sellerId={data.memberId}
+          productId={String(data.productId)}
+          isOwner={isOwner}
+        />
 
         <div className="px-6 mt-12">
-          <ButtonComponent
-            className="w-full"
-            variant="primary"
-            size="xl"
-            onClick={onBuy}
-            disabled={isOwner}
-          >
-            {isOwner ? "내 게시글입니다" : "구매하기"}
+          <ButtonComponent className="w-full" variant="primary" size="xl" onClick={onBuy}>
+            구매하기
           </ButtonComponent>
           {error && <p className="body-sm text-error text-center">{error}</p>}
         </div>

--- a/src/feature/map/components/sections/seller/MapProfileCard.tsx
+++ b/src/feature/map/components/sections/seller/MapProfileCard.tsx
@@ -4,13 +4,15 @@ import { ButtonComponent } from "@components/common/button";
 import { useQuery } from "@tanstack/react-query";
 import { getMyInfo } from "@feature/mypage/apis/mypageRequest";
 import { Rating, RatingButton } from "@components/common/rating/RatingScore";
+import { toast } from "react-toastify";
 
 interface MapProfileCardProps {
   sellerId: number;
   productId: string;
+  isOwner?: boolean;
 }
 
-export default function MapProfileCard({ sellerId, productId }: MapProfileCardProps) {
+export default function MapProfileCard({ sellerId, productId, isOwner }: MapProfileCardProps) {
   const router = useRouter();
 
   const { data } = useQuery({
@@ -24,6 +26,10 @@ export default function MapProfileCard({ sellerId, productId }: MapProfileCardPr
 
   const goToChat = (e: React.MouseEvent) => {
     e.stopPropagation();
+    if (isOwner) {
+      toast.info("내 게시글입니다");
+      return;
+    }
     router.push(`/chat/${productId}`);
   };
 

--- a/src/feature/map/components/sections/seller/SellerSection.tsx
+++ b/src/feature/map/components/sections/seller/SellerSection.tsx
@@ -3,13 +3,14 @@ import MapProfileCard from "@/feature/map/components/sections/seller/MapProfileC
 interface SellerSectionProps {
   sellerId: number;
   productId: string;
+  isOwner?: boolean;
 }
 
-export default function SellerSection({ sellerId, productId }: SellerSectionProps) {
+export default function SellerSection({ sellerId, productId, isOwner }: SellerSectionProps) {
   return (
     <div className="px-6 py-6 rounded-lg">
       <h3 className="title-md mb-4 mt-12">판매자</h3>
-      <MapProfileCard sellerId={sellerId} productId={productId} />
+      <MapProfileCard sellerId={sellerId} productId={productId} isOwner={isOwner} />
     </div>
   );
 }


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->

- 맵 상세 페이지에서 사용자가 본인 게시글을 조회 중일 경우,
구매하기 버튼 비활성화 및 안내 토스트 노출
채팅 이동 제한 및 안내 토스트 노출

https://github.com/user-attachments/assets/7c354b34-b4ab-4ddf-8c6f-f3c0386145cc


## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->

- SellerSection → MapProfileCard까지 isOwner prop 전달 구조 정리
- 버튼 텍스트는 항상 "구매하기"로 고정, 대신 비활성화 시 토스트로 안내


## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #193 

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
