### PR TITLE
[DP-224] feat: FCM 알림 appheader에 추가 #176

### DIFF
--- a/src/components/common/header/AppHeader.tsx
+++ b/src/components/common/header/AppHeader.tsx
@@ -3,10 +3,11 @@ import { PropsWithChildren, useMemo } from "react";
 import HeaderTimer from "./HeaderTimer";
 import Image from "next/image";
 import { cn } from "@lib/utils";
-import BackButton from "./BackButton";
-import HeaderTitle from "./HeaderTitle";
+import BackButton from "@components/common/header/BackButton";
+import HeaderTitle from "@components/common/header/HeaderTitle";
 import { usePathname } from "next/navigation";
 import { useHeaderStore } from "@stores/useHeaderStore";
+import NotificationIcon from "@components/common/NotificationIcon";
 
 interface AppHeaderProps {
   id?: string;
@@ -35,6 +36,7 @@ export default function AppHeader({ id, children }: PropsWithChildren<AppHeaderP
     () => (
       <>
         <HeaderTimer />
+        <NotificationIcon />
       </>
     ),
     []

--- a/src/feature/notification/utils/requestFcmToken.ts
+++ b/src/feature/notification/utils/requestFcmToken.ts
@@ -3,7 +3,7 @@ import { app } from "@/lib/firebase";
 import { postFcmToken } from "@feature/notification/api/requestNotification";
 
 export const requestFcmToken = async () => {
-  // SSR 방지용: window 없는 경우 return
+  // SSR 환경에서는 실행 방지
   if (typeof window === "undefined" || !("Notification" in window)) return;
 
   const permission = await Notification.requestPermission();
@@ -11,16 +11,24 @@ export const requestFcmToken = async () => {
 
   try {
     const messaging = getMessaging(app);
-    const token = await getToken(messaging, {
-      vapidKey: process.env.NEXT_PUBLIC_FIREBASE_VAPID_KEY!,
-      serviceWorkerRegistration: await navigator.serviceWorker.register("/firebase-messaging-sw.js"),
+    const registration = await navigator.serviceWorker.register("/firebase-messaging-sw.js");
 
+    const newToken = await getToken(messaging, {
+      vapidKey: process.env.NEXT_PUBLIC_FIREBASE_VAPID_KEY!,
+      serviceWorkerRegistration: registration,
     });
-    console.log("FCM TOKEN: ",token)
-    if (token) {
-      await postFcmToken(token);
+
+    if (!newToken) return;
+
+    const savedToken = localStorage.getItem("fcmToken");
+
+    if (newToken !== savedToken) {
+      await postFcmToken(newToken);
+      localStorage.setItem("fcmToken", newToken);
     }
+
+    console.log("FCM 토큰 처리 완료:", newToken);
   } catch (error) {
-    console.error("FCM 토큰 요청 실패", error);
+    console.error("FCM 토큰 요청 실패:", error);
   }
 };


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->

- 기존 SharedHeader -> AppHeader로 바뀌면서 AppHeader에도 NotificationIcon 추가해 헤더에서 알림페이지로 접근 가능
- `requestFcmToken` 로직 내에 localStorage를 이용한 중복 저장 방지 로직 추가

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->

- 테스트 해볼 상황
  - 알림 허용 → FCM 토큰 정상 발급 확인
  - 토큰 중복 저장 없이 `/api/fcm/save` 단 한 번만 호출되는지 확인
  - 헤더에 알림 아이콘 정상 노출되고 알림페이지 리다이렉트되는지 확인

<img width="312" height="673" alt="스크린샷 2025-07-31 오후 1 17 09" src="https://github.com/user-attachments/assets/02c7484a-b583-401c-85e6-763001d18093" />


## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #176

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
