### PR TITLE
[DP-240] feat: 채팅방 진입 시 memberId 기반 로직 개선 및 WebSocket 안정성 향상 #203

### DIFF
--- a/src/feature/chat/api/chatRoomRequest.ts
+++ b/src/feature/chat/api/chatRoomRequest.ts
@@ -41,7 +41,6 @@ export const markMessageAsRead = async (chatMessageId: number | string) => {
       throw new Error(response.data.message || "메시지 읽음 처리 실패");
     }
   } catch (error) {
-    console.error("메시지 읽음 처리 실패:", error);
     throw error;
   }
 };

--- a/src/feature/chat/api/getChatHistory.ts
+++ b/src/feature/chat/api/getChatHistory.ts
@@ -8,6 +8,7 @@ interface ChatHistoryResponse {
     hasNext: boolean;
     size: number;
   };
+  memberId: number;
 }
 
 export async function getChatHistory(
@@ -29,6 +30,7 @@ export async function getChatHistory(
       return {
         data: response.data.data.data,
         pageInfo: response.data.data.pageInfo,
+        memberId: response.data.data.memberId,
       };
     } else {
       throw new Error(response.data.message || "채팅 기록 조회 실패");

--- a/src/feature/chat/components/sections/list/ChatItem.tsx
+++ b/src/feature/chat/components/sections/list/ChatItem.tsx
@@ -13,7 +13,7 @@ export interface ChatItemProps {
   productId: number;
   place?: string;
   pricePer10min?: number;
-  memberId?: number;
+  senderId?: number;
   lastMessage?: string;
 }
 
@@ -25,15 +25,15 @@ export default function ChatItem({
   avatarUrl,
   productId,
   place,
-  memberId,
+  senderId,
   lastMessage,
 }: ChatItemProps) {
   const router = useRouter();
 
   const handleAvatarClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (memberId) {
-      router.push(`/data/review?id=${memberId}&tab=review`);
+    if (senderId) {
+      router.push(`/data/review?id=${senderId}&tab=review`);
     } else {
       router.push("/data/review");
     }
@@ -47,7 +47,7 @@ export default function ChatItem({
         <Link
           href={`/chat/${chatRoomId}?productId=${productId}&memberName=${encodeURIComponent(
             name
-          )}&memberId=${memberId || ""}`}
+          )}&senderId=${senderId || ""}`}
           className="flex-1"
         >
           <div className="flex flex-col gap-2 cursor-pointer">

--- a/src/feature/chat/components/sections/list/ChatItem.tsx
+++ b/src/feature/chat/components/sections/list/ChatItem.tsx
@@ -13,7 +13,7 @@ export interface ChatItemProps {
   productId: number;
   place?: string;
   pricePer10min?: number;
-  senderId?: number;
+  memberId?: number;
   lastMessage?: string;
 }
 
@@ -25,15 +25,15 @@ export default function ChatItem({
   avatarUrl,
   productId,
   place,
-  senderId,
+  memberId,
   lastMessage,
 }: ChatItemProps) {
   const router = useRouter();
 
   const handleAvatarClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (senderId) {
-      router.push(`/data/review?id=${senderId}&tab=review`);
+    if (memberId) {
+      router.push(`/data/review?id=${memberId}&tab=review`);
     } else {
       router.push("/data/review");
     }
@@ -45,9 +45,9 @@ export default function ChatItem({
           <AvatarIcon avatar={avatarUrl} size="medium" />
         </button>
         <Link
-          href={`/chat/${chatRoomId}?productId=${productId}&senderName=${encodeURIComponent(
+          href={`/chat/${chatRoomId}?productId=${productId}&memberName=${encodeURIComponent(
             name
-          )}&senderId=${senderId || ""}`}
+          )}&memberId=${memberId || ""}`}
           className="flex-1"
         >
           <div className="flex flex-col gap-2 cursor-pointer">

--- a/src/feature/chat/components/sections/room/ChatBubble.tsx
+++ b/src/feature/chat/components/sections/room/ChatBubble.tsx
@@ -18,7 +18,8 @@ export default function ChatBubble({
   senderId,
   currentMemberId,
 }: ChatBubbleProps) {
-  const isMine = message.memberId ? message.memberId === currentMemberId : message.isMine;
+  const isMine = message.senderId ? message.senderId === currentMemberId : message.isMine;
+
   const timeText = formatTimeToAmPm(message.createdAt);
 
   const baseClasses =

--- a/src/feature/chat/components/sections/room/ChatBubble.tsx
+++ b/src/feature/chat/components/sections/room/ChatBubble.tsx
@@ -9,10 +9,16 @@ interface ChatBubbleProps {
   message: ChatSocketMessage;
   avatarUrl?: string;
   senderId?: number;
+  currentMemberId?: number;
 }
 
-export default function ChatBubble({ message, avatarUrl, senderId }: ChatBubbleProps) {
-  const isMine = message.isMine;
+export default function ChatBubble({
+  message,
+  avatarUrl,
+  senderId,
+  currentMemberId,
+}: ChatBubbleProps) {
+  const isMine = message.memberId ? message.memberId === currentMemberId : message.isMine;
   const timeText = formatTimeToAmPm(message.createdAt);
 
   const baseClasses =

--- a/src/feature/chat/components/sections/room/ChatBubble.tsx
+++ b/src/feature/chat/components/sections/room/ChatBubble.tsx
@@ -8,17 +8,18 @@ import { cn } from "@/lib/utils";
 interface ChatBubbleProps {
   message: ChatSocketMessage;
   avatarUrl?: string;
-  senderId?: number;
+  memberId?: number;
   currentMemberId?: number;
 }
 
 export default function ChatBubble({
   message,
   avatarUrl,
-  senderId,
+  memberId,
   currentMemberId,
 }: ChatBubbleProps) {
-  const isMine = message.senderId ? message.senderId === currentMemberId : message.isMine;
+  const isMine =
+    message.senderId !== undefined ? message.senderId === currentMemberId : message.isMine;
 
   const timeText = formatTimeToAmPm(message.createdAt);
 
@@ -32,7 +33,7 @@ export default function ChatBubble({
     <div className={cn("flex items-end gap-2", isMine ? "justify-end" : "justify-start")}>
       {!isMine && (
         <Link
-          href={senderId ? `/data/review?id=${senderId}&tab=review` : "/data/review"}
+          href={memberId ? `/data/review?id=${memberId}&tab=review` : "/data/review"}
           className="cursor-pointer"
         >
           <AvatarIcon avatar={avatarUrl} size="small" />

--- a/src/feature/chat/components/sections/room/ChatRoomContent.tsx
+++ b/src/feature/chat/components/sections/room/ChatRoomContent.tsx
@@ -44,7 +44,7 @@ export default function ChatRoomContent({ chatRoomId, productId }: ChatRoomConte
   // 중복 요청 방지를 위한 ref들
   const lastReadMessageId = useRef<number | null>(null);
   const isExiting = useRef(false);
-  const abortControllerRef = useRef<AbortController | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
   const lastProductId = useRef<string | null>(null);
 
   const { subscribe, unsubscribe, sendMessage, setActiveChatRoomId } = useWebSocketStore();
@@ -97,8 +97,8 @@ export default function ChatRoomContent({ chatRoomId, productId }: ChatRoomConte
   useEffect(() => {
     if (!chatRoomId) return;
 
-    abortControllerRef.current?.abort();
-    abortControllerRef.current = new AbortController();
+    abortRef.current?.abort();
+    abortRef.current = new AbortController();
 
     setMessages([]);
     setLoadingMore(false);
@@ -110,7 +110,7 @@ export default function ChatRoomContent({ chatRoomId, productId }: ChatRoomConte
 
     getChatHistory(chatRoomId)
       .then((response) => {
-        if (abortControllerRef.current?.signal.aborted) return;
+        if (abortRef.current?.signal.aborted) return;
 
         const messagesWithSenderId = addSenderIdToMessages(response.data, response.memberId);
         setMessages(messagesWithSenderId);
@@ -134,7 +134,7 @@ export default function ChatRoomContent({ chatRoomId, productId }: ChatRoomConte
       });
 
     return () => {
-      abortControllerRef.current?.abort();
+      abortRef.current?.abort();
     };
   }, [chatRoomId]);
 

--- a/src/feature/chat/types/chatType.ts
+++ b/src/feature/chat/types/chatType.ts
@@ -24,7 +24,7 @@ export interface ChatSocketMessage {
   isMine: boolean;
   senderName?: string;
   unreadCount?: number;
-  memberId?: number;
+  senderId?: number;
 }
 
 export interface CursorPageResponse<T> {

--- a/src/feature/chat/types/chatType.ts
+++ b/src/feature/chat/types/chatType.ts
@@ -24,6 +24,7 @@ export interface ChatSocketMessage {
   isMine: boolean;
   senderName?: string;
   unreadCount?: number;
+  memberId?: number;
 }
 
 export interface CursorPageResponse<T> {

--- a/src/feature/chat/utils/chatUtils.ts
+++ b/src/feature/chat/utils/chatUtils.ts
@@ -1,0 +1,22 @@
+import type { ChatSocketMessage } from "@/feature/chat/types/chatType";
+import { formatDateDivider } from "@/lib/time";
+
+export const isTemporaryMessage = (message: ChatSocketMessage): boolean => {
+  if (typeof message.chatMessageId === "number") {
+    return message.chatMessageId >= 1000000000000;
+  }
+  return false;
+};
+
+export const formatMessageDate = (createdAt: string): string => {
+  try {
+    const date = new Date(createdAt);
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    return `${year}년 ${month}월 ${day}일`;
+  } catch (error) {
+    console.error("날짜 파싱 오류:", error);
+    return formatDateDivider();
+  }
+};

--- a/src/feature/chat/utils/groupMessagesByDate.ts
+++ b/src/feature/chat/utils/groupMessagesByDate.ts
@@ -1,29 +1,29 @@
 import type { ChatSocketMessage } from "@/feature/chat/types/chatType";
+import { formatMessageDate } from "@/feature/chat/utils/chatUtils";
 
 interface GroupedMessages {
   date: string;
   messages: ChatSocketMessage[];
 }
 
-//채팅 메시지를 날짜별로 그룹화
+//채팅 메시지를 날짜별로 그룹화 (메시지 ID 기준)
 export function groupMessagesByDate(messages: ChatSocketMessage[]): GroupedMessages[] {
   const groups: { [date: string]: ChatSocketMessage[] } = {};
 
   messages.forEach((msg) => {
-    const date = msg.createdAt.split("T")[0];
+    // 모든 메시지에 대해 createdAt 사용 (임시/실제 구분 없이)
+    const date = formatMessageDate(msg.createdAt);
+
     if (!groups[date]) {
       groups[date] = [];
     }
     groups[date].push(msg);
   });
 
-  // 날짜 순 정렬 + 각 그룹 내 messages도 시간순 정렬
   return Object.entries(groups)
     .sort(([a], [b]) => new Date(a).getTime() - new Date(b).getTime())
     .map(([date, messages]) => ({
       date,
-      messages: messages.sort(
-        (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-      ),
+      messages: messages.sort((a, b) => Number(a.chatMessageId) - Number(b.chatMessageId)),
     }));
 }

--- a/src/feature/map/components/sections/product/MapItemContent.tsx
+++ b/src/feature/map/components/sections/product/MapItemContent.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback } from "react";
+import { Fragment, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ImageIcon, Star } from "lucide-react";
 import { ButtonComponent } from "@components/common/button";
@@ -12,24 +12,31 @@ export default function MapItemCardContent({
   data: { productId, address, price, score, title, startTime, endTime, open, imageUrl },
 }: ProductItemProps<MapType> & { disableUseButton?: boolean }) {
   const router = useRouter();
-  const handleCreateChatRoom = useCallback(
-    async (e: React.MouseEvent) => {
-      e.stopPropagation();
-      try {
-        const response = await axiosInstance.post(`/api/products/${productId}/chat-room`);
-        if (response.data.code === 0) {
-          const chatRoomId = response.data.data.chatRoomId;
-          router.push(`/chat/${chatRoomId}?productId=${productId}`);
-        } else {
-          toast.error(response.data.message || "채팅방 생성에 실패했습니다.");
-        }
-      } catch (error) {
-        toast.error("채팅방 생성 중 오류가 발생했습니다.");
-        console.error(error);
+  const [isCreatingChat, setIsCreatingChat] = useState(false);
+
+  const handleCreateChatRoom = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+
+    if (isCreatingChat) return;
+
+    setIsCreatingChat(true);
+
+    try {
+      const response = await axiosInstance.post(`/api/products/${productId}/chat-room`);
+      if (response.data.code === 0) {
+        const chatRoomId = response.data.data.chatRoomId;
+        router.push(`/chat/${chatRoomId}?productId=${productId}`);
+      } else {
+        toast.error(response.data.message || "채팅방 생성에 실패했습니다.");
       }
-    },
-    [productId, router]
-  );
+    } catch (error) {
+      toast.error("채팅방 생성 중 오류가 발생했습니다.");
+      console.error(error);
+    } finally {
+      setIsCreatingChat(false);
+    }
+  };
+
   console.log(startTime, endTime);
   return (
     <Fragment>
@@ -97,8 +104,9 @@ export default function MapItemCardContent({
           variant="outlineGray"
           className="flex-2"
           onClick={handleCreateChatRoom}
+          disabled={isCreatingChat}
         >
-          채팅하기
+          {isCreatingChat ? "생성중..." : "채팅하기"}
         </ButtonComponent>
       </div>
     </Fragment>

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -208,11 +208,3 @@ export function formatDateDivider(date?: string | Date): string {
   const day = targetDate.getDate();
   return `${year}년 ${month}월 ${day}일`;
 }
-
-export function formatChatDateDivider(): string {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = now.getMonth() + 1;
-  const day = now.getDate();
-  return `${year}년 ${month}월 ${day}일`;
-}

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -200,10 +200,19 @@ export const isTimeInRange = (target: Time, min: Time, max: Time): boolean => {
   return targetMins >= minMins && targetMins <= maxMins;
 };
 
-export function formatDateDivider(isoOrDateString: string): string {
-  const date = new Date(isoOrDateString);
-  const year = date.getFullYear();
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
+// 기존 함수를 수정 (실제 날짜 데이터를 받도록)
+export function formatDateDivider(date?: string | Date): string {
+  const targetDate = date ? new Date(date) : new Date();
+  const year = targetDate.getFullYear();
+  const month = targetDate.getMonth() + 1;
+  const day = targetDate.getDate();
+  return `${year}년 ${month}월 ${day}일`;
+}
+
+export function formatChatDateDivider(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth() + 1;
+  const day = now.getDate();
   return `${year}년 ${month}월 ${day}일`;
 }

--- a/src/stores/useWebSocketStore.ts
+++ b/src/stores/useWebSocketStore.ts
@@ -41,12 +41,14 @@ export const useWebSocketStore = create<WebSocketStore>((set, get) => ({
       webSocketFactory: () => {
         const sock = new SockJS(`${apiBaseUrl}/conn`, null, {
           transports: ["websocket", "xhr-streaming", "xhr-polling"],
-          timeout: 15000,
+          timeout: 30000,
         });
 
         return sock;
       },
       reconnectDelay: 5000,
+      heartbeatIncoming: 4000,
+      heartbeatOutgoing: 4000,
       onConnect: () => {
         set({ isConnected: true });
 
@@ -75,6 +77,13 @@ export const useWebSocketStore = create<WebSocketStore>((set, get) => ({
       onStompError: (frame) => {
         console.error("STOMP 오류:", frame.headers["message"]);
         set({ isConnected: false, subscriptionObjects: new Map() });
+
+        setTimeout(() => {
+          const { client } = get();
+          if (client && !client.connected) {
+            client.activate();
+          }
+        }, 5000);
       },
     });
 


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->

- 채팅방 진입 시 사용자 식별을 위한 memberId 값을 기반으로 읽음 처리 로직을 개선하고, 전송 및 수신 메시지의 일관성을 위해 전반적인 로직을 리팩토링했습니다.
- getChatHistory 응답에 memberId 포함 → 상태로 관리하여 메시지 주인 판별에 활용
- ChatBubble에서 senderId 대신 memberId 기준으로 isMine 판별
- ChatInputBar 메시지 전송 시 로딩 처리 및 임시 메시지 UI 개선
- WebSocket 수신 메시지에 대한 파싱 및 오류 처리 추가
- groupMessagesByDate에서 날짜 포맷 유틸 함수 개선
- MapItemContent 채팅 생성 중 중복 요청 방지 및 상태 처리
- WebSocketStore:
      - 중복 구독 방지 로직 보완 (subscriptions + subscriptionObjects 동시 확인)
      - 메시지 전송/수신 시 try-catch 처리로 안정성 향상
      - 구독 해제 시 subscription 정보 정리 로직 개선
      - updateUnreadCount 함수 전체 리스트 기준으로 변경
      - STOMP 클라이언트에 heartbeat 설정 추가로 연결 안정성 개선
      - STOMP 오류 발생 시 자동 재연결 시도 로직 추가

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->

- 콘솔 로그나 주석은 추후 개발 완료 후 전체적으로 삭제할 예정입니다.

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #203 

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
