### PR TITLE
[DP-258] fix: 상대방 버블 avatar 경로 수정 #222

### DIFF
--- a/src/feature/chat/components/sections/room/ChatRoomContent.tsx
+++ b/src/feature/chat/components/sections/room/ChatRoomContent.tsx
@@ -14,6 +14,7 @@ import { getChatHistory } from "@/feature/chat/api/getChatHistory";
 import { markMessageAsRead } from "@/feature/chat/api/chatRoomRequest";
 import { getMapDetailById } from "@/feature/map/api/getMapDetailById";
 import { isTemporaryMessage, formatMessageDate } from "@/feature/chat/utils/chatUtils";
+import { getMyInfo } from "@/feature/mypage/apis/mypageRequest";
 
 interface ChatRoomContentProps {
   chatRoomId: number;
@@ -36,6 +37,7 @@ export default function ChatRoomContent({ chatRoomId, productId }: ChatRoomConte
   const [oldestMessageId, setOldestMessageId] = useState<number | undefined>(undefined);
   const [product, setProduct] = useState<ProductInfo | null>(null);
   const [currentMemberId, setCurrentMemberId] = useState<number | undefined>(undefined);
+  const [senderProfileImage, setSenderProfileImage] = useState<string | undefined>(undefined);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const searchParams = useSearchParams();
 
@@ -351,6 +353,18 @@ export default function ChatRoomContent({ chatRoomId, productId }: ChatRoomConte
   const senderName = urlSenderName || product?.memberName || "상대방";
   const senderId = urlSenderId ? parseInt(urlSenderId, 10) : product?.memberId;
 
+  useEffect(() => {
+    if (senderId && !senderProfileImage) {
+      getMyInfo(senderId)
+        .then((userInfo) => {
+          setSenderProfileImage(userInfo.profileImageUrl);
+        })
+        .catch((error) => {
+          console.error(error);
+        });
+    }
+  }, [senderId, senderProfileImage]);
+
   // 헤더 제목 설정
   useEffect(() => {
     setTitle(senderName);
@@ -389,6 +403,7 @@ export default function ChatRoomContent({ chatRoomId, productId }: ChatRoomConte
                 <ChatBubble
                   key={message.chatMessageId}
                   message={message}
+                  avatarUrl={senderProfileImage}
                   memberId={senderId}
                   currentMemberId={currentMemberId}
                 />

--- a/src/feature/chat/types/chatType.ts
+++ b/src/feature/chat/types/chatType.ts
@@ -23,6 +23,7 @@ export interface ChatSocketMessage {
   createdAt: string;
   isMine: boolean;
   senderName?: string;
+  senderProfileImageUrl?: string;
   unreadCount?: number;
   senderId?: number;
 }


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 상대방 채팅 버블에 프로필 이미지(avatarUrl)가 정상적으로 표시되지 않던 이슈 수정
- product.memberId 또는 URL로부터 상대방 ID를 받아 해당 유저 정보를 조회하고 프로필 이미지를 상태로 관리
- getMyInfo(senderId) API를 통해 상대방 프로필 이미지 URL을 가져와 ChatBubble에 전달
- 최초 1회만 호출되도록 senderId && !senderProfileImage 조건으로 useEffect 구성


## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->

-

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #222 

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
