### PR TITLE
[DP-259] refactor: 사용자 정보 연동 및 WebSocket 연결 개선

### DIFF
--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,9 +1,30 @@
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(req: NextRequest) {
-  const refreshToken = req.cookies.get("accessToken");
+  const accessToken = req.cookies.get("accessToken");
 
-  const isLogin = !!refreshToken;
+  const isLogin = !!accessToken;
 
-  return NextResponse.json({ isLogin });
+  if (isLogin) {
+    try {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_SSL}/api/members/info`, {
+        headers: {
+          Cookie: `accessToken=${accessToken.value}`,
+        },
+        credentials: "include",
+      });
+
+      if (response.ok) {
+        const userData = await response.json();
+        return NextResponse.json({
+          isLogin: true,
+          user: userData,
+        });
+      }
+    } catch (error) {
+      console.error("사용자 정보 조회 실패:", error);
+    }
+  }
+
+  return NextResponse.json({ isLogin: false });
 }

--- a/src/feature/chat/components/sections/room/ChatRoomContent.tsx
+++ b/src/feature/chat/components/sections/room/ChatRoomContent.tsx
@@ -372,7 +372,7 @@ export default function ChatRoomContent({ chatRoomId, productId }: ChatRoomConte
         </div>
       )}
 
-      <div className="flex-1 overflow-y-auto px-4 pt-20" onScroll={handleScroll}>
+      <div className="flex-1 overflow-y-auto px-4 pt-20 pb-36" onScroll={handleScroll}>
         {loadingMore && (
           <div className="text-center text-sm text-gray-500 py-4">이전 내역을 불러오는 중...</div>
         )}

--- a/src/feature/mypage/components/sections/LogOutButton.tsx
+++ b/src/feature/mypage/components/sections/LogOutButton.tsx
@@ -1,10 +1,18 @@
 import { ButtonComponent } from "@components/common/button";
 import { useAuth } from "@hooks/useAuth";
+import { useWebSocketConnection } from "@/hooks/useWebSocketConnection";
 
 export default function LogOutButton() {
   const { logout } = useAuth();
+  const { disconnectOnLogout } = useWebSocketConnection();
+
+  const handleLogout = async () => {
+    disconnectOnLogout();
+    await logout();
+  };
+
   return (
-    <ButtonComponent variant={"outlinePrimary"} className="w-full" onClick={logout}>
+    <ButtonComponent variant={"outlinePrimary"} className="w-full" onClick={handleLogout}>
       로그아웃
     </ButtonComponent>
   );

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -2,18 +2,26 @@ import { logOutRequest } from "@apis/userProfile";
 import Cookies from "js-cookie";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
+import { useProfileStore } from "@/stores/useProfileStore";
 
 export function useAuth() {
   const router = useRouter();
   const token = Cookies.get("accessToken");
   const [isLogin, setIsLogin] = useState<boolean | null>(null);
+  const { setProfile } = useProfileStore();
 
   useEffect(() => {
     fetch("/api/auth/me")
       .then((res) => res.json())
-      .then((data) => setIsLogin(data.isLogin))
+      .then((data) => {
+        setIsLogin(data.isLogin);
+
+        if (data.isLogin && data.user) {
+          setProfile(data.user);
+        }
+      })
       .catch(() => setIsLogin(false));
-  }, []);
+  }, [setProfile]);
 
   const logout = async () => {
     const res = await logOutRequest();

--- a/src/hooks/useWebSocketConnection.ts
+++ b/src/hooks/useWebSocketConnection.ts
@@ -21,6 +21,14 @@ export const useWebSocketConnection = () => {
 
   const disconnectOnLogout = () => {
     disconnect();
+    useProfileStore.getState().setProfile({
+      name: "",
+      profileImageUrl: "",
+      joinedAt: "",
+      averageRating: 0,
+      reviewCount: 0,
+      tradeCount: 0,
+    });
   };
 
   return {

--- a/src/stores/useProfileStore.ts
+++ b/src/stores/useProfileStore.ts
@@ -13,7 +13,7 @@ interface ProfileStoreProps extends Partial<UserType> {
  * @param showAvatar 추후 default value => undefined로 수정해야 함
  */
 export const useProfileStore = create<ProfileStoreProps>((set) => ({
-  id: 17,
+  id: undefined,
   setUserName: (newName) => {
     set({ name: newName });
   },


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 사용자 정보를 /api/auth/me 요청 시 가져오고, Zustand useProfileStore에 저장
- WebSocket 연결 시 사용자 정보가 세팅되어 있을 때만 연결되도록 개선
- 로그아웃 시 WebSocket 연결 해제와 함께 사용자 정보 초기화

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->

-기존 하드코딩된 userId 제거
- 마이페이지 로그아웃 버튼 → disconnectOnLogout + logout() 통합 처리

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #259

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
