### PR TITLE
[DP-264] fix: 구매가능/판매가능 뱃지 style 수정 #237

### DIFF
--- a/src/components/common/badge/BadgeComponent.tsx
+++ b/src/components/common/badge/BadgeComponent.tsx
@@ -4,6 +4,6 @@ import { Badge } from "@ui/badge";
 
 import { cn } from "@/lib/utils";
 
-export function BadgeComponent({ className, variant, ...props }: BadgeProps) {
-  return <Badge className={cn(badgeVariants({ variant }), className)} {...props} />;
+export function BadgeComponent({ className, variant, size, ...props }: BadgeProps) {
+  return <Badge className={cn(badgeVariants({ variant, size }), className)} {...props} />;
 }

--- a/src/components/common/badge/badgeVariants.ts
+++ b/src/components/common/badge/badgeVariants.ts
@@ -8,11 +8,13 @@ export const badgeVariants = cva("inline-flex items-center justify-center rounde
       label: "px-3 bg-primary text-white",
       meta: "px-3 text-black",
       outlined: "px-3 bg-white border border-primary/20 text-black",
+      largeOutlined: "px-8 py-4 bg-white border border-primary/20 text-black text-body-lg"
     },
     size: {
       sm: "h-[20px]",
       md: "h-[22px]",
       lg: "h-[25px]",
+      xl: "h-[32px]",
     },
   },
   defaultVariants: {

--- a/src/components/common/badge/badgeVariants.ts
+++ b/src/components/common/badge/badgeVariants.ts
@@ -8,7 +8,7 @@ export const badgeVariants = cva("inline-flex items-center justify-center rounde
       label: "px-3 bg-primary text-white",
       meta: "px-3 text-black",
       outlined: "px-3 bg-white border border-primary/20 text-black",
-      largeOutlined: "px-8 py-4 bg-white border border-primary/20 text-black text-body-lg"
+      largeOutlined: "px-8 py-4 bg-white border border-primary/20 text-black title-xs"
     },
     size: {
       sm: "h-[20px]",

--- a/src/feature/data/components/pages/DataDetailContent.tsx
+++ b/src/feature/data/components/pages/DataDetailContent.tsx
@@ -114,11 +114,11 @@ export default function DataDetailContent() {
           )}
           {!isLimitLoading && (
             <div className="flex flex-wrap gap-8">
-              <BadgeComponent variant="outlined">
+              <BadgeComponent variant="largeOutlined" size="xl">
                 이번 달 구매 가능:{" "}
                 <span className="font-semibold ml-4">{formatDataSize(remainingBuying ?? 0)}</span>
               </BadgeComponent>
-              <BadgeComponent variant="outlined">
+              <BadgeComponent variant="largeOutlined" size="xl">
                 이번 달 판매 가능:{" "}
                 <span className="font-semibold ml-4">{formatDataSize(remainingSelling ?? 0)}</span>
               </BadgeComponent>


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->

- `badgevariant` 추가 : `largeoutlined`
- `BadgeComponent`에서 `badgeVariants({ variant })` 호출 시 `size` prop을 누락했던 부분을 수정하여 `size`도 함께 전달되도록 변경
- `badgeVariants`의 size variant (`sm`, `md`, `lg`, `xl` )가 정상 작용

<img width="604" height="767" alt="스크린샷 2025-08-02 오전 9 42 47" src="https://github.com/user-attachments/assets/92e9b377-36c8-4396-93d4-6c4fd4524986" />


## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->

- 데이터 게시글 상세페이지에서 뱃지 확인 가능

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #237 

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
