### PR TITLE
[DP-270] fix: 자투리구매 price 계산 오류 수정 #258

### DIFF
--- a/src/feature/data/api/scrapRecommendation.ts
+++ b/src/feature/data/api/scrapRecommendation.ts
@@ -1,28 +1,27 @@
 import axios from "@lib/axios";
 import { ScrapRecommendationSummary } from "@feature/data/types/scrapTypes";
-import { mapRawToDataType, DataType, RawDataItem } from "@feature/data/types/dataType";
+import { RawDataItem } from "@feature/data/types/dataType";
 
 export async function getScrapRecommendation(
-    requestedAmount: number
-  ): Promise<{ items: DataType[]; summary: ScrapRecommendationSummary }> {
-    try {
-      const response = await axios.get("/api/trades/mobile-data/scrap", {
-        params: { dataAmount: requestedAmount },
-      });
-  
-      const rawItems: RawDataItem[] = response.data.data.combinations;
-      const summary: ScrapRecommendationSummary = {
-        totalAmount: response.data.data.totalAmount,
-        totalPrice: response.data.data.totalPrice,
-      };
-  
-      const items: DataType[] = rawItems.map(mapRawToDataType);
-      return { items, summary };
-    } catch (error) {
-      console.error("자투리 조합 조회 실패", error);
-      return {
-        items: [],
-        summary: { totalAmount: 0, totalPrice: 0 },
-      };
-    }
+  requestedAmount: number
+): Promise<{ items: RawDataItem[]; summary: ScrapRecommendationSummary }> {
+  try {
+    const response = await axios.get("/api/trades/mobile-data/scrap", {
+      params: { dataAmount: requestedAmount },
+    });
+
+    const rawItems: RawDataItem[] = response.data.data.combinations;
+    const summary: ScrapRecommendationSummary = {
+      totalAmount: response.data.data.totalAmount,
+      totalPrice: response.data.data.totalPrice,
+    };
+
+    return { items: rawItems, summary };
+  } catch (error) {
+    console.error("자투리 조합 조회 실패", error);
+    return {
+      items: [],
+      summary: { totalAmount: 0, totalPrice: 0 },
+    };
   }
+}

--- a/src/feature/data/hooks/useScrapRecommendation.ts
+++ b/src/feature/data/hooks/useScrapRecommendation.ts
@@ -1,35 +1,31 @@
 import { useState } from "react";
 import { getScrapRecommendation } from "@feature/data/api/scrapRecommendation";
 import { ScrapRecommendationSummary } from "@feature/data/types/scrapTypes";
-import { DataType } from "@feature/data/types/dataType";
+import { RawDataItem } from "@feature/data/types/dataType";
 
 export function useScrapRecommendation() {
-    const [value, setValue] = useState<number[]>([1]);
-    const [loading, setLoading] = useState(false);
-    const [result, setResult] = useState<DataType[]>([]);
-    const [summary, setSummary] = useState<ScrapRecommendationSummary>({
-        totalAmount: 0,
-        totalPrice: 0,
-    });
+  const [value, setValue] = useState<number[]>([1]);
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<RawDataItem[]>([]);
+  const [summary, setSummary] = useState<ScrapRecommendationSummary>({
+    totalAmount: 0,
+    totalPrice: 0,
+  });
 
-    const fetchRecommendation = async (amount: number) => {
-        return await getScrapRecommendation(amount);
-      };
-      const search = async () => {
-        setLoading(true);
-        const { items, summary } = await fetchRecommendation(value[0]);
-        setResult(items);
-        setSummary(summary);
-        setLoading(false);
-      };
-      console.log("result: ",result)
+  const search = async () => {
+    setLoading(true);
+    const { items, summary } = await getScrapRecommendation(value[0]);
+    setResult(items);
+    setSummary(summary);
+    setLoading(false);
+  };
 
-    return {
-        value,
-        setValue,
-        loading,
-        result,
-        summary,
-        search,
-    };
+  return {
+    value,
+    setValue,
+    loading,
+    result,
+    summary,
+    search,
+  };
 }


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->

- 자투리 구매 시 `purchasePrice` 계산이 잘못되는 문제 수정
  - `pricePer100MB`가 문자열로 변환된 `DataType` 기준으로 계산되던 문제 해결
  - 원본 `RawDataItem`을 사용하여 정확한 숫자 기반 계산 적용
- `getScrapRecommendation` → `RawDataItem[]` 반환으로 수정
- `useScrapRecommendation` 및 `ScrapTabContent`에서 타입 및 데이터 흐름 리팩터링
  - UI 표시는 `DataType[]`으로 `mapRawToDataType()` 사용
  - 결제 전송 데이터는 `RawDataItem` 기반으로 정확하게 계산

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->

- 자투리 구매 조회, 결제 잘 되는지 확인
- 자투리 구매 후 게시글 확인 

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #258 

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
