### PR TITLE
[DP-277] fix: 프로필 이미지 업로드 후 UI 즉시 반영되도록 수정

### DIFF
--- a/src/feature/mypage/components/sections/profile/AvatarUploader.tsx
+++ b/src/feature/mypage/components/sections/profile/AvatarUploader.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useRef, useState, useEffect } from "react";
 import { Pencil } from "lucide-react";
 import AvatarIcon from "@components/common/AvatarIcon";
 import { usePresignedUpload } from "@hooks/usePresignedUpload";
@@ -15,13 +15,19 @@ interface AvatarUploaderProps {
 export default function AvatarUploader({ avatarUrl }: AvatarUploaderProps) {
     const inputRef = useRef<HTMLInputElement>(null);
     const queryClient = useQueryClient();
+    const [currentAvatarUrl, setCurrentAvatarUrl] = useState<string | undefined>(avatarUrl);
+
+    useEffect(() => {
+        setCurrentAvatarUrl(avatarUrl);
+    }, [avatarUrl]);
 
     const { uploadFiles } = usePresignedUpload();
 
     const { mutate } = useMutation({
         mutationFn: updateProfileImage,
-        onSuccess: () => {
+        onSuccess: (_, newAvatarUrl) => {
             queryClient.invalidateQueries({ queryKey: ["/api/members/info"] });
+            setCurrentAvatarUrl(newAvatarUrl);
             toast.success("프로필 이미지가 변경되었습니다!");
         },
         onError: (e: unknown) => {
@@ -49,7 +55,7 @@ export default function AvatarUploader({ avatarUrl }: AvatarUploaderProps) {
 
     return (
         <div className="relative w-fit">
-            <AvatarIcon size="large" avatar={avatarUrl} />
+            <AvatarIcon size="large" avatar={currentAvatarUrl} />
             <button
                 onClick={() => inputRef.current?.click()}
                 className="absolute bottom-0 right-0 w-24 h-24 rounded-full bg-white border border-gray-300 flex items-center justify-center hover:bg-gray-100 transition"


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->

- 프로필 이미지 업로드 후, 응답받은 URL을 `useState`로 즉시 상태에 업데이트
- 이미지 변경 성공 즉시 UI가 새로고침 없이 자동으로 갱신되고 성공 토스트 뜸
- `React Query` 캐시 무효화 유지하여 서버 상태와의 일관성 보장


![profile-upload-refetch](https://github.com/user-attachments/assets/a7e7e6fe-0d89-4eb4-a826-9a63c5cf1420)

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->

- 프로필 사진 업로드후 새로고침 없이도 자동 반영되는지 확인! 

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
