### PR TITLE
[DP-279] feat: 충전/환불 페이지 이탈 시 금액 초기화 처리 및 금액 0원 제한 #270

### DIFF
--- a/src/feature/mypage/components/pages/CashActionContent.tsx
+++ b/src/feature/mypage/components/pages/CashActionContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { useChargeStore } from "@feature/mypage/stores/useChargeStore";
 import { useTossModalStore } from "@feature/mypage/stores/useTossModalStore";
 import { useCashSuccessModalStore } from "@feature/mypage/stores/useCashSuccessModalStore";
@@ -21,11 +21,18 @@ interface CashActionContentProps {
 
 export default function CashActionContent({ mode, buttonText }: CashActionContentProps) {
     const chargeAmount = useChargeStore((state) => state.charge);
+    const setChargeAmount = useChargeStore((state) => state.setCharge);
     const openToss = useTossModalStore((state) => state.open);
     const { isOpen, close, open } = useCashSuccessModalStore();
 
+    useEffect(() => {
+        return () => {
+            setChargeAmount("");
+        };
+    }, [setChargeAmount]);
+    
     const handleClick = useCallback(async () => {
-        if (!chargeAmount) {
+        if (!chargeAmount || chargeAmount === "0") {
             toast.error(mode === "charge" ? "충전 금액을 입력해주세요." : "환불 금액을 입력해주세요.");
             return;
         }
@@ -38,11 +45,12 @@ export default function CashActionContent({ mode, buttonText }: CashActionConten
                 const res = await requestRefund(requestId, Number(chargeAmount));
                 toast.success(`${res.data.data.refundPrice.toLocaleString()}원 환불 완료`);
                 open("refund");
+                setChargeAmount("");
             } catch {
                 toast.error("환불에 실패했습니다.");
             }
         }
-    }, [chargeAmount, mode, openToss, open]);
+    }, [chargeAmount, mode, openToss, open, setChargeAmount]);
 
     return (
         <>


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->

- `CashActionContent` 컴포넌트에서 언마운트 시 charge 값 초기화하는 useEffect 추가
- 사용자가 페이지를 벗어났다가 다시 돌아왔을 때 이전 금액이 유지되지 않도록 개선
- 충전,환불 금액 0원 입력 시 제한되고 에러 토스트

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->

-

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #270 

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
