### PR TITLE
[DP-297] fix: toss widjet 재오픈 시 렌더링 안되는 오류 수정 #289

### DIFF
--- a/src/feature/mypage/components/sections/toss/TossPaymentModal.tsx
+++ b/src/feature/mypage/components/sections/toss/TossPaymentModal.tsx
@@ -13,12 +13,15 @@ export default function TossPaymentModal() {
   const rendered = useRef(false);
 
   useEffect(() => {
-    if (isOpen && !rendered.current && charge) {
+    if (!isOpen) {
+      rendered.current = false;
+    } else if (!rendered.current && charge) {
       rendered.current = true;
       renderTossPayment(charge);
       console.log("호출됨: renderTossPayment with charge =", charge);
     }
   }, [isOpen, charge]);
+  
 
   if (!isOpen) return null;
 


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->

- TossPaymentModal에서 모달을 닫은 후 다시 열면 결제 위젯이 보이지 않는 이슈 발생
- 위젯 렌더링 여부를 관리하는 `rendered.current`가 한 번 true가 된 뒤 초기화되지 않았음
- `useEffect`에서 모달이 닫힐 때 `rendered.current = false`로 초기화
- 모달 재오픈 시에도 정상적으로 `renderTossPayment`가 호출되어 위젯이 보이도록 수정

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->

- 추후 위젯 상태를 좀 더 명확하게 관리하려면 상태 기반 로직으로 리팩토링 고려
- toss widjet 렌더링 잘되는지 확인 부탁드려요! 

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #289 

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
