### PR TITLE
[DP-298] feat: 보유캐시 부족시 충전페이지로 리다이렉트 #291

### DIFF
--- a/src/feature/mypage/components/sections/profile/SelectCharge.tsx
+++ b/src/feature/mypage/components/sections/profile/SelectCharge.tsx
@@ -18,9 +18,22 @@ export default function SelectCharge({ title = "충전 금액 선택" }: SelectC
   const setSelectValue = useChargeStore((state) => state.setCharge);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    setSelectValue(e.currentTarget.value);
-  };
+    const rawValue = e.currentTarget.value;
 
+    const numericValue = rawValue.replace(/[^0-9]/g, "");
+  
+    if (numericValue === "") {
+      setSelectValue("");
+      return;
+    }
+  
+    const num = Number(numericValue);
+  
+    if (num >= 0 && num <= 10000000) {
+      setSelectValue(numericValue);
+    }
+  };
+  
   const handleButtonClick = (e: MouseEvent<HTMLButtonElement>) => {
     setSelectValue(e.currentTarget.value);
   };


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->

- 결제 요청 실패 시 서버에서 응답받은 에러 코드 4004(보유 캐시 부족)에 대응
- 해당 에러 발생 시 토스트 메시지 노출 후 `/mypage/charge`로 리다이렉트
- 캐시 충전금액 입력 제한 (0~10000000) 추가

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->

- 캐시0원일 경우 리다이렉트 잘 되는지 확인해주세요! 

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #291 

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
