### PR TITLE
[DP-305] feat: mixpanel setting 사용자 식별 및 페이지 뷰 자동추적 기능 추가 #301

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "js-cookie": "^3.0.5",
         "lodash": "^4.17.21",
         "lucide-react": "^0.525.0",
+        "mixpanel-browser": "^2.67.0",
         "next": "^15.3.4",
         "next-themes": "^0.4.6",
         "react": "^19.1.0",
@@ -2917,6 +2918,18 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@rrweb/types": {
+      "version": "2.0.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.18.tgz",
+      "integrity": "sha512-iMH3amHthJZ9x3gGmBPmdfim7wLGygC2GciIkw2A6SO8giSn8PHYtRT8OKNH4V+k3SZ6RSnYHcTQxBA7pSWZ3Q==",
+      "license": "MIT"
+    },
+    "node_modules/@rrweb/utils": {
+      "version": "2.0.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.0.0-alpha.18.tgz",
+      "integrity": "sha512-qV8azQYo9RuwW4NGRtOiQfTBdHNL1B0Q//uRLMbCSjbaKqJYd88Js17Bdskj65a0Vgp2dwTLPIZ0gK47dfjfaA==",
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3385,6 +3398,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -4096,6 +4115,12 @@
         }
       }
     },
+    "node_modules/@xstate/fsm": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
+      "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -4470,6 +4495,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -7756,6 +7790,21 @@
         "node": ">= 18"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/mixpanel-browser": {
+      "version": "2.67.0",
+      "resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.67.0.tgz",
+      "integrity": "sha512-LudY4eRIkvjEpAlIAg10i2T2mbtiKZ4XlMGbTyF1kcAhEqMa9JhEEdEcjxYPwiKhuMVSBM3RVkNCZaNqcnE4ww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "rrweb": "2.0.0-alpha.18"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
@@ -8225,7 +8274,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8606,6 +8654,40 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rrdom": {
+      "version": "2.0.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.0.0-alpha.18.tgz",
+      "integrity": "sha512-fSFzFFxbqAViITyYVA4Z0o5G6p1nEqEr/N8vdgSKie9Rn0FJxDSNJgjV0yiCIzcDs0QR+hpvgFhpbdZ6JIr5Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "rrweb-snapshot": "^2.0.0-alpha.18"
+      }
+    },
+    "node_modules/rrweb": {
+      "version": "2.0.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.0-alpha.18.tgz",
+      "integrity": "sha512-1mjZcB+LVoGSx1+i9E2ZdAP90fS3MghYVix2wvGlZvrgRuLCbTCCOZMztFCkKpgp7/EeCdYM4nIHJkKX5J1Nmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rrweb/types": "^2.0.0-alpha.18",
+        "@rrweb/utils": "^2.0.0-alpha.18",
+        "@types/css-font-loading-module": "0.0.7",
+        "@xstate/fsm": "^1.4.0",
+        "base64-arraybuffer": "^1.0.1",
+        "mitt": "^3.0.0",
+        "rrdom": "^2.0.0-alpha.18",
+        "rrweb-snapshot": "^2.0.0-alpha.18"
+      }
+    },
+    "node_modules/rrweb-snapshot": {
+      "version": "2.0.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.18.tgz",
+      "integrity": "sha512-hBHZL/NfgQX6wO1D9mpwqFu1NJPpim+moIcKhFEjVTZVRUfCln+LOugRc4teVTCISYHN8Cw5e2iNTWCSm+SkoA==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^8.4.38"
       }
     },
     "node_modules/run-parallel": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "js-cookie": "^3.0.5",
     "lodash": "^4.17.21",
     "lucide-react": "^0.525.0",
+    "mixpanel-browser": "^2.67.0",
     "next": "^15.3.4",
     "next-themes": "^0.4.6",
     "react": "^19.1.0",

--- a/src/components/common/PageViewTracker.tsx
+++ b/src/components/common/PageViewTracker.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+import { trackEvent } from "@/lib/mixpanel";
+
+export default function PageViewTracker() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    trackEvent("Page View", {
+      path: pathname,
+    });
+  }, [pathname]);
+
+  return null;
+}

--- a/src/components/common/PageViewTracker.tsx
+++ b/src/components/common/PageViewTracker.tsx
@@ -2,15 +2,25 @@
 
 import { useEffect } from "react";
 import { usePathname } from "next/navigation";
-import { trackEvent } from "@/lib/mixpanel";
+import { trackEvent, isInitialized } from "@/lib/mixpanel";
 
 export default function PageViewTracker() {
   const pathname = usePathname();
 
   useEffect(() => {
-    trackEvent("Page View", {
-      path: pathname,
-    });
+    if (!isInitialized) {
+      const timer = setTimeout(() => {
+        if (isInitialized) {
+          trackEvent("Page View", { path: pathname });
+        } else {
+          console.warn("PageView skipped: Mixpanel still not initialized.");
+        }
+      }, 300);
+
+      return () => clearTimeout(timer);
+    } else {
+      trackEvent("Page View", { path: pathname });
+    }
   }, [pathname]);
 
   return null;

--- a/src/components/common/ProviderWrapper.tsx
+++ b/src/components/common/ProviderWrapper.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { PropsWithChildren } from "react";
 import TimerContainer from "@/feature/map/components/sections/timer/TimeContainer";
@@ -8,6 +9,9 @@ import { useSubscribeTimer } from "@hooks/useSubscribeTimer";
 import { useInitializeTimerFromServer } from "@hooks/useInitializeTimerFormServer";
 import { useSubscribeTimerOnce } from "@hooks/subscribeToTimerOnce";
 import { useWebSocketConnection } from "@/hooks/useWebSocketConnection";
+import { initMixpanel } from "@lib/mixpanel";
+import mixpanel from "mixpanel-browser";
+import PageViewTracker from "@components/common/PageViewTracker";
 
 export default function ProviderWrapper({ children }: PropsWithChildren) {
   const queryClient = new QueryClient();
@@ -20,8 +24,21 @@ export default function ProviderWrapper({ children }: PropsWithChildren) {
   useSubscribeTimer(userId, isLoading);
   useInitializeTimerFromServer();
 
+  useEffect(() => {
+    initMixpanel();
+  }, []);
+
+  useEffect(() => {
+    if (userId) {
+      mixpanel.identify(userId.toString());
+      mixpanel.people.set({
+        $name: user.name,
+      });
+    }
+  }, [userId]);
   return (
     <QueryClientProvider client={queryClient}>
+      <PageViewTracker />
       {children}
       <TimerContainer />
     </QueryClientProvider>

--- a/src/lib/mixpanel.ts
+++ b/src/lib/mixpanel.ts
@@ -1,0 +1,18 @@
+import mixpanel from "mixpanel-browser";
+
+const token = process.env.NEXT_PUBLIC_MIXPANEL_TOKEN ?? "";
+
+export const initMixpanel = () => {
+  if (!token) return;
+  mixpanel.init(token, {
+    debug: process.env.NODE_ENV === "development",
+    track_pageview: true,
+    persistence: "localStorage",
+  });
+};
+
+export const trackEvent = (eventName: string, properties?: Record<string, any>) => {
+    mixpanel.track(eventName, properties);
+  };
+
+export default mixpanel;

--- a/src/lib/mixpanel.ts
+++ b/src/lib/mixpanel.ts
@@ -2,17 +2,27 @@ import mixpanel from "mixpanel-browser";
 
 const token = process.env.NEXT_PUBLIC_MIXPANEL_TOKEN ?? "";
 
+export let isInitialized = false;
+
 export const initMixpanel = () => {
   if (!token) return;
+  if (isInitialized) return;
+
   mixpanel.init(token, {
     debug: process.env.NODE_ENV === "development",
-    track_pageview: true,
+    track_pageview: false,
     persistence: "localStorage",
   });
+
+  isInitialized = true;
 };
 
 export const trackEvent = (eventName: string, properties?: Record<string, any>) => {
-    mixpanel.track(eventName, properties);
-  };
+  if (!isInitialized) {
+    console.warn("❗️Mixpanel is not initialized yet. Event skipped:", eventName);
+    return;
+  }
 
-export default mixpanel;
+  mixpanel.track(eventName, properties);
+};
+


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->

- `mixpanel-browser`를 이용한 Mixpanel SDK 클라이언트 초기화
- `ProviderWrapper`에서 사용자 로그인 정보 기반 `identify` + `people.set` 호출
- 공통 페이지 뷰 자동 추적을 위한 `PageViewTracker` 컴포넌트 추가
- `lib/mixpanel.ts`에 `initMixpanel`, `trackEvent` 유틸 함수 정의
- 이벤트 초기화 타이밍 문제 대응 (`isInitialized` 체크 로직 포함)

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->

- 테스트시 
  - 로컬에서 페이지 진입 시 `Page View` 이벤트 정상 발생 확인
  - `Live View`에서 이벤트 수신 및 유저 식별 확인됨
- 버튼 클릭 등 주요 유저 이벤트는 이후 점진적으로 `trackEvent()`로 연동 예정


## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #301 

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
