### PR TITLE
[DP-318] feat: 데이터 등록 실패 메시지 toast 출력 및 toast 한번만 뜨도록 수정 #316

### DIFF
--- a/src/components/common/modal/ReportModal.tsx
+++ b/src/components/common/modal/ReportModal.tsx
@@ -9,8 +9,8 @@ import { useMutation } from "@tanstack/react-query";
 import { registReport } from "@apis/reportRequest";
 import ReportCompleteModal from "./ReportCompleteModal";
 import { AxiosError } from "axios";
-import { toast } from "react-toastify";
 import FullScreenModal from "./FullScreenModal";
+import { showErrorToast } from "@lib/toast";
 
 interface ReportModalProps {
   isOpen: boolean;
@@ -48,10 +48,10 @@ export default function ReportModal({ isOpen, setIsOpen, targetId, targetName }:
     onError: (e: AxiosError) => {
       switch (e.status) {
         case 409:
-          return toast.error("이미 신고 처리중입니다.");
+          return showErrorToast("이미 신고 처리중입니다.");
         default:
           console.error(e.status);
-          return toast.error("신고 처리중 오류가 발생했습니다.");
+          return showErrorToast("신고 처리중 오류가 발생했습니다.");
       }
     },
   });
@@ -62,7 +62,7 @@ export default function ReportModal({ isOpen, setIsOpen, targetId, targetName }:
   }, [setIsOpen]);
   const handleReportClick = useCallback(() => {
     if (!reportReason || reportReason === "") {
-      toast.error("신고 사유를 작성해 주세요.");
+      showErrorToast("신고 사유를 작성해 주세요.");
       ref.current?.focus();
     } else {
       reportMutation.mutate();

--- a/src/feature/data/api/dataRequest.ts
+++ b/src/feature/data/api/dataRequest.ts
@@ -53,13 +53,19 @@ export const postMobileDataProduct = async (
   price: number,
   isSplitType: boolean
 ) => {
-  const res = await axios.post("/api/products/mobile-data", {
-    price,
-    dataAmount,
-    isSplitType,
-  });
+  try {
+    const res = await axios.post("/api/products/mobile-data", {
+      price,
+      dataAmount,
+      isSplitType,
+    });
 
-  return res.data;
+    return res.data;
+  } catch (error: any) {
+    const message =
+      error?.response?.data?.message ?? "데이터 상품 등록에 실패했습니다.";
+    throw new Error(message);
+  }
 };
 
 export const getPriceRecommendation = async () => {

--- a/src/feature/data/components/sections/default/OverLimitAlert.tsx
+++ b/src/feature/data/components/sections/default/OverLimitAlert.tsx
@@ -19,7 +19,7 @@ export default function OverLimitAlert({
   if (!isSplitType && remainAmount > remainingBuying) {
     return (
       <p className="body-xxs text-error">
-        ⚠️ 구매 가능 용량을 초과했습니다. 최대 {formatDataSize(remainingBuying)}까지 구매할 수 있어요.
+        ⚠️ 최대 구매 가능 용량을 초과했습니다. 최대 {formatDataSize(remainingBuying)}까지 구매할 수 있어요.
       </p>
     );
   }
@@ -28,7 +28,7 @@ export default function OverLimitAlert({
   if (isSplitType && selectedAmount >= remainingBuying) {
     return (
       <p className="body-xxs text-error text-left mt-8">
-        ⚠️ 구매 가능 용량을 초과했습니다. 최대 {formatDataSize(remainingBuying)}까지 선택할 수 있어요.
+        ⚠️ 이번 달 최대 구매 가능 용량에 도달했습니다. 최대 {formatDataSize(remainingBuying)}까지 선택할 수 있어요.
       </p>
     );
   }

--- a/src/feature/data/components/sections/modal/DataRegistModal.tsx
+++ b/src/feature/data/components/sections/modal/DataRegistModal.tsx
@@ -89,7 +89,7 @@ export default function DataRegistModal({
         />
         {value[0] >= maxAmount && (
           <p className="body-xxs text-error mt-20">
-            이번 달 최대 판매 가능량을 모두 사용하셨습니다.
+            이번 달 최대 판매 가능량을 등록하시겠습니까?
           </p>
         )}
       </FlatCard>

--- a/src/feature/data/components/sections/modal/DataRegistModal.tsx
+++ b/src/feature/data/components/sections/modal/DataRegistModal.tsx
@@ -10,8 +10,8 @@ import { useRegisterDataProduct } from "@feature/data/hooks/useRegisterDataProdu
 import { useUpdateDataProduct } from "@feature/data/hooks/useUpdateDataProduct";
 import { useMonthlyDataLimit } from "@feature/data/hooks/useMonthlyDataLimit";
 import { Switch } from "@ui/switch";
-import { toast } from "react-toastify";
 import { useRouter } from "next/navigation";
+import { showErrorToast, showSuccessToast } from "@lib/toast";
 
 interface DataRegistModalProps {
   onClose: () => void;
@@ -45,7 +45,7 @@ export default function DataRegistModal({
     const priceInt = parseInt(price, 10);
 
     if (isNaN(priceInt) || priceInt <= 0) {
-      toast.error("유효한 가격을 입력해주세요.");
+      showErrorToast("유효한 가격을 입력해주세요.");
       return;
     }
 
@@ -56,7 +56,7 @@ export default function DataRegistModal({
         price: priceInt,
         isSplitType: isSplit,
         onSuccess: () => {
-          toast.success("수정 완료!");
+          showSuccessToast("수정 완료!");
           onClose();
           router.refresh();
         },

--- a/src/feature/data/hooks/useRegisterDataProduct.ts
+++ b/src/feature/data/hooks/useRegisterDataProduct.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { postMobileDataProduct } from "@feature/data/api/dataRequest";
-import { toast } from "react-toastify";
 import { useQueryClient } from "@tanstack/react-query";
+import { showErrorToast, showSuccessToast } from "@lib/toast";
 
 export const useRegisterDataProduct = () => {
     const queryClient = useQueryClient();
@@ -19,7 +19,7 @@ export const useRegisterDataProduct = () => {
             onSuccess?: () => void;
         }) => {
             if (isNaN(price) || price <= 0) {
-                toast.error("유효한 가격을 입력해주세요.");
+                showErrorToast("유효한 가격을 입력해주세요.");
                 return;
             }
 
@@ -28,13 +28,13 @@ export const useRegisterDataProduct = () => {
                 const res = await postMobileDataProduct(dataAmount, price, isSplitType);
 
                 if (res.code === 0) {
-                    toast.success("등록 완료!");
+                    showSuccessToast("등록 완료!");
                     queryClient.invalidateQueries({ queryKey: ["dataItems"] });
                     onSuccess?.();
                 }
             } catch (e) {
                 console.error(e);
-                toast.error((e as Error).message);
+                showErrorToast((e as Error).message);
             }
         },
         [queryClient]

--- a/src/feature/data/hooks/useRegisterDataProduct.ts
+++ b/src/feature/data/hooks/useRegisterDataProduct.ts
@@ -34,7 +34,7 @@ export const useRegisterDataProduct = () => {
                 }
             } catch (e) {
                 console.error(e);
-                toast.error("등록 중 오류가 발생했습니다.");
+                toast.error((e as Error).message);
             }
         },
         [queryClient]

--- a/src/feature/data/hooks/useUpdateDataProduct.ts
+++ b/src/feature/data/hooks/useUpdateDataProduct.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
-import { toast } from "react-toastify";
 import {  useQueryClient } from "@tanstack/react-query";
 import { putMobileDataProduct } from "@feature/data/api/dataRequest";
+import { showSuccessToast } from "@lib/toast";
 
 export const useUpdateDataProduct = () => {
   const queryClient = useQueryClient();
@@ -24,12 +24,12 @@ export const useUpdateDataProduct = () => {
         const res = await putMobileDataProduct({ productId, changedAmount, price, isSplitType });
         if (res.code === 0) {
           queryClient.invalidateQueries({ queryKey: ["dataDetail", productId.toString()] });
-          toast.success("수정이 완료되었습니다.");
+          showSuccessToast("수정이 완료되었습니다.");
           onSuccess?.();
         }
       } catch (e) {
         console.error(e);
-        toast.error("수정 중 오류가 발생했습니다.");
+        showSuccessToast("수정 중 오류가 발생했습니다.");
       }
     },
     [queryClient]

--- a/src/feature/map/components/pages/MapDetailPage.tsx
+++ b/src/feature/map/components/pages/MapDetailPage.tsx
@@ -12,12 +12,12 @@ import DeletePostModal from "@/feature/data/components/sections/modal/DeletePost
 import { parseHHMMToTime, isWithinOperatingHours } from "@/lib/time";
 import { useWifiPriceRecommendation } from "@/feature/map/hooks/useWifiPriceRecommendation";
 import { usePaymentStore } from "@feature/payment/stores/paymentStore";
-import { toast } from "react-toastify";
 import { getDurationMinutes } from "@/lib/time";
 
 import clsx from "clsx";
 import { buildWifiPaymentInfo } from "@feature/payment/hooks/useWifiPurchaseBuilder";
 import UsePaymentModals from "@feature/payment/hooks/usePaymentModals";
+import { showErrorToast, showInfoToast } from "@lib/toast";
 
 export default function MapDetailPage() {
   const router = useRouter();
@@ -59,18 +59,18 @@ export default function MapDetailPage() {
 
   const onBuy = () => {
     if (isOwner) {
-      toast.info("내 게시글입니다");
+      showInfoToast("내 게시글입니다");
       return;
     }
 
     if (!isWithinOperatingHours(startTime, endTime, minTime, maxTime)) {
-      toast.warning("선택한 시간이 매장의 운영시간 범위를 벗어납니다.");
+      showErrorToast("선택한 시간이 매장의 운영시간 범위를 벗어납니다.");
       return;
     }
 
     const duration = getDurationMinutes(startTime, endTime);
     if (duration % 10 !== 0) {
-      toast.warning("이용 시간은 10분 단위로 선택해야 합니다.");
+      showErrorToast("이용 시간은 10분 단위로 선택해야 합니다.");
       return;
     }
 

--- a/src/feature/map/components/sections/list/MapListVirtual.tsx
+++ b/src/feature/map/components/sections/list/MapListVirtual.tsx
@@ -3,7 +3,7 @@ import VirtualizedInfiniteList from "@/components/common/list/VirtualizedInfinit
 import MapItemCard from "@/feature/map/components/sections/product/MapItemCard";
 import { useMapInfiniteQuery } from "@/feature/map/hooks/useMapInfiniteQuery";
 import type { MapType } from "@/feature/map/types/mapType";
-import { toast } from "react-toastify";
+import { showErrorToast } from "@lib/toast";
 
 export default function MapListVirtual() {
   const [coords, setCoords] = useState<{ lat: number; lng: number } | null>(null);
@@ -13,7 +13,7 @@ export default function MapListVirtual() {
       ({ coords }) => {
         setCoords({ lat: coords.latitude, lng: coords.longitude });
       },
-      () => toast.error("위치 정보를 가져올 수 없습니다.")
+      () => showErrorToast("위치 정보를 가져올 수 없습니다.")
     );
   }, []);
 

--- a/src/feature/map/components/sections/product/MapFloatingButtons.tsx
+++ b/src/feature/map/components/sections/product/MapFloatingButtons.tsx
@@ -2,7 +2,7 @@ import { PlusIcon, ListIcon, LocateFixed } from "lucide-react";
 import { ButtonComponent } from "@components/common/button";
 import { useMapStore } from "@/feature/map/stores/useMapStore";
 import { motion, AnimatePresence } from "framer-motion";
-import { toast } from "react-toastify";
+import { showErrorToast } from "@lib/toast";
 
 interface Props {
   onOpenModal: () => void;
@@ -21,7 +21,7 @@ export default function MapFloatingButtons({ onOpenModal, onOpenSheet, isSnapOpe
         map.setCenter(location);
         map.setZoom(15);
       },
-      () => toast.error("위치 정보를 가져올 수 없습니다."),
+      () => showErrorToast("위치 정보를 가져올 수 없습니다."),
       { enableHighAccuracy: true }
     );
   };

--- a/src/feature/map/components/sections/product/MapItemContent.tsx
+++ b/src/feature/map/components/sections/product/MapItemContent.tsx
@@ -5,9 +5,9 @@ import { ButtonComponent } from "@components/common/button";
 import type { ProductItemProps } from "@/feature/data/types/dataType";
 import type { MapType } from "@/feature/map/types/mapType";
 import axiosInstance from "@/lib/axios";
-import { toast } from "react-toastify";
 import Image from "next/image";
 import { getMapDetailById } from "@/feature/map/api/getMapDetailById";
+import { showErrorToast } from "@lib/toast";
 
 export default function MapItemCardContent({
   data: { productId, address, price, score, title, startTime, endTime, open, imageUrl },
@@ -41,10 +41,10 @@ export default function MapItemCardContent({
             router.push(url);
           }
         } else {
-          toast.error(response.data.message || "채팅방 생성에 실패했습니다.");
+          showErrorToast(response.data.message || "채팅방 생성에 실패했습니다.");
         }
       } catch (error) {
-        toast.error("채팅방 생성 중 오류가 발생했습니다.");
+        showErrorToast("채팅방 생성 중 오류가 발생했습니다.");
         console.error(error);
       }
     },

--- a/src/feature/map/components/sections/review/ReviewBottomSheet.tsx
+++ b/src/feature/map/components/sections/review/ReviewBottomSheet.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { toast } from "react-toastify";
 import { Check, Star, X } from "lucide-react";
 import { AxiosError } from "axios";
 import BaseBottomSheet from "@/components/common/bottomsheet/BaseBottomSheet";
@@ -10,6 +9,7 @@ import { useReviewMutation } from "@/feature/map/hooks/useReviewMutation";
 import InputComponent from "@components/common/input/InputComponent";
 import { ReviewResponse } from "@/feature/map/types/reviewType";
 import { useRouter } from "next/navigation";
+import { showErrorToast } from "@lib/toast";
 
 export interface ReviewBottomSheetProps {
   isOpen: boolean;
@@ -28,7 +28,7 @@ export default function ReviewBottomSheet({ isOpen, onClose, tradeId }: ReviewBo
     () => setStep("complete"),
     (e: AxiosError<unknown>) => {
       const message = (e.response?.data as ReviewResponse)?.message;
-      toast.error(message || "리뷰 등록에 실패했습니다.");
+      showErrorToast(message || "리뷰 등록에 실패했습니다.");
     }
   );
 

--- a/src/feature/map/components/sections/seller/MapProfileCard.tsx
+++ b/src/feature/map/components/sections/seller/MapProfileCard.tsx
@@ -4,9 +4,9 @@ import { ButtonComponent } from "@components/common/button";
 import { useQuery } from "@tanstack/react-query";
 import { getMyInfo } from "@feature/mypage/apis/mypageRequest";
 import { Rating, RatingButton } from "@components/common/rating/RatingScore";
-import { toast } from "react-toastify";
 import { useCallback } from "react";
 import axiosInstance from "@/lib/axios";
+import { showErrorToast, showInfoToast } from "@lib/toast";
 
 interface MapProfileCardProps {
   sellerId: number;
@@ -38,7 +38,7 @@ export default function MapProfileCard({
     async (e: React.MouseEvent) => {
       e.stopPropagation();
       if (isOwner) {
-        toast.info("내 게시글입니다");
+        showInfoToast("내 게시글입니다");
         return;
       }
 
@@ -54,10 +54,10 @@ export default function MapProfileCard({
           const url = `/chat/${chatRoomId}?${params.toString()}`;
           router.push(url);
         } else {
-          toast.error(response.data.message || "채팅방 생성에 실패했습니다.");
+          showErrorToast(response.data.message || "채팅방 생성에 실패했습니다.");
         }
       } catch (error) {
-        toast.error("채팅방 생성 중 오류가 발생했습니다.");
+        showErrorToast("채팅방 생성 중 오류가 발생했습니다.");
         console.error(error);
       }
     },

--- a/src/feature/map/hooks/useMapInitializer.ts
+++ b/src/feature/map/hooks/useMapInitializer.ts
@@ -3,7 +3,7 @@ import { useMapStore } from "@/feature/map/stores/useMapStore";
 import type { MapType } from "@/feature/map/types/mapType";
 import { MAP_CONTAINER_ID, DEFAULT_LOCATION } from "@/feature/map/constants/map";
 import { getMapList } from "@/feature/map/api/mapRequest";
-import { toast } from "react-toastify";
+import { showErrorToast } from "@lib/toast";
 
 interface UseMapInitializerOptions {
   onStoreListUpdate?: (list: MapType[]) => void;
@@ -65,11 +65,11 @@ export const useMapInitializer = (options?: UseMapInitializerOptions) => {
             setStoreList(res.items);
             options?.onStoreListUpdate?.(res.items);
           } catch (e) {
-            toast.error("와이파이 목록을 불러오는 데 실패했습니다.");
+            showErrorToast("와이파이 목록을 불러오는 데 실패했습니다.");
             console.error(e);
           }
         },
-        () => toast.error("위치 정보를 가져올 수 없습니다."),
+        () => showErrorToast("위치 정보를 가져올 수 없습니다."),
         { enableHighAccuracy: true }
       );
     }, 100);

--- a/src/feature/mypage/components/pages/CashActionContent.tsx
+++ b/src/feature/mypage/components/pages/CashActionContent.tsx
@@ -11,8 +11,8 @@ import SelectCharge from "@feature/mypage/components/sections/profile/SelectChar
 import ChargeInfoCard from "@feature/mypage/components/sections/profile/ChargeInfoCard";
 import TossPaymentModal from "@feature/mypage/components/sections/toss/TossPaymentModal";
 import CashSuccessModal from "@feature/mypage/components/sections/toss/CashSuccessModal";
-import { toast } from "react-toastify";
 import { v4 as uuidv4 } from "uuid";
+import { showErrorToast, showSuccessToast } from "@lib/toast";
 
 interface CashActionContentProps {
     mode: "charge" | "refund";
@@ -33,7 +33,7 @@ export default function CashActionContent({ mode, buttonText }: CashActionConten
     
     const handleClick = useCallback(async () => {
         if (!chargeAmount || chargeAmount === "0") {
-            toast.error(mode === "charge" ? "충전 금액을 입력해주세요." : "환불 금액을 입력해주세요.");
+            showErrorToast(mode === "charge" ? "충전 금액을 입력해주세요." : "환불 금액을 입력해주세요.");
             return;
         }
 
@@ -43,11 +43,11 @@ export default function CashActionContent({ mode, buttonText }: CashActionConten
             const requestId = `refund-${uuidv4()}`;
             try {
                 const res = await requestRefund(requestId, Number(chargeAmount));
-                toast.success(`${res.data.data.refundPrice.toLocaleString()}원 환불 완료`);
+                showSuccessToast(`${res.data.data.refundPrice.toLocaleString()}원 환불 완료`);
                 open("refund");
                 setChargeAmount("");
             } catch {
-                toast.error("환불에 실패했습니다.");
+                showErrorToast("환불에 실패했습니다.");
             }
         }
     }, [chargeAmount, mode, openToss, open, setChargeAmount]);

--- a/src/feature/mypage/components/sections/profile/AvatarUploader.tsx
+++ b/src/feature/mypage/components/sections/profile/AvatarUploader.tsx
@@ -6,7 +6,7 @@ import AvatarIcon from "@components/common/AvatarIcon";
 import { usePresignedUpload } from "@hooks/usePresignedUpload";
 import { updateProfileImage } from "@feature/mypage/apis/mypageRequest";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { toast } from "react-toastify";
+import { showErrorToast, showSuccessToast } from "@lib/toast";
 
 interface AvatarUploaderProps {
     avatarUrl?: string;
@@ -28,13 +28,13 @@ export default function AvatarUploader({ avatarUrl }: AvatarUploaderProps) {
         onSuccess: (_, newAvatarUrl) => {
             queryClient.invalidateQueries({ queryKey: ["/api/members/info"] });
             setCurrentAvatarUrl(newAvatarUrl);
-            toast.success("프로필 이미지가 변경되었습니다!");
+            showSuccessToast("프로필 이미지가 변경되었습니다!");
         },
         onError: (e: unknown) => {
             if (e instanceof Error) {
-                toast.error(e.message);
+                showErrorToast(e.message);
             } else {
-                toast.error("프로필 이미지 변경 실패");
+                showErrorToast("프로필 이미지 변경 실패");
             }
         },
     });
@@ -49,7 +49,7 @@ export default function AvatarUploader({ avatarUrl }: AvatarUploaderProps) {
                 mutate(urls[0]);
             }
         } catch {
-            toast.error("업로드 중 오류가 발생했습니다");
+            showErrorToast("업로드 중 오류가 발생했습니다");
         }
     };
 

--- a/src/feature/mypage/hooks/useHandleTossSuccess.ts
+++ b/src/feature/mypage/hooks/useHandleTossSuccess.ts
@@ -3,7 +3,7 @@
 import { useSearchParams, useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { confirmPayment, verifyPaymentAmount } from "@/feature/mypage/apis/payment";
-import { toast } from "react-toastify";
+import { showErrorToast } from "@lib/toast";
 
 export const useHandleTossSuccess = () => {
   const searchParams = useSearchParams();
@@ -16,7 +16,7 @@ export const useHandleTossSuccess = () => {
 
     const handle = async () => {
       if (!paymentKey || !orderId || !amount) {
-        toast.error("잘못된 결제 정보입니다.");
+        showErrorToast("잘못된 결제 정보입니다.");
         router.replace("/mypage?error=invalid");
         return;
       }
@@ -24,20 +24,20 @@ export const useHandleTossSuccess = () => {
       try {
         const verifyRes = await verifyPaymentAmount(orderId, amount);
         if (verifyRes.data.code !== 0) {
-          toast.error("결제 금액 검증 실패");
+          showErrorToast("결제 금액 검증 실패");
           router.replace("/mypage?error=verify");
           return;
         }
 
         const confirmRes = await confirmPayment(paymentKey, orderId, amount);
         if (confirmRes.data.code !== 0) {
-          toast.error("결제 승인 실패");
+          showErrorToast("결제 승인 실패");
           router.replace("/mypage?error=confirm");
           return;
         }
         router.replace("/mypage?payment=success");
       } catch {
-        toast.error("결제 처리 중 오류 발생");
+        showErrorToast("결제 처리 중 오류 발생");
         router.replace("/mypage?error=unknown");
       }
     };

--- a/src/feature/mypage/hooks/useTossPayment.ts
+++ b/src/feature/mypage/hooks/useTossPayment.ts
@@ -7,7 +7,7 @@ import {
 } from "@tosspayments/tosspayments-sdk";
 import { savePaymentAmount } from "@feature/mypage/apis/payment";
 import { v4 as uuidv4 } from "uuid";
-import { toast } from "react-toastify";
+import { showErrorToast } from "@lib/toast";
 
 export const useTossPayment = () => {
   const clientKey = process.env.NEXT_PUBLIC_TOSS_CLIENT_KEY!;
@@ -19,7 +19,7 @@ export const useTossPayment = () => {
   const renderTossPayment = async (chargeStr: string) => {
     const amount = Number(chargeStr);
     if (!amount || isNaN(amount) || amount <= 0) {
-      toast.error("유효한 결제 금액을 입력해주세요.");
+      showErrorToast("유효한 결제 금액을 입력해주세요.");
       return;
     }
 
@@ -40,7 +40,7 @@ export const useTossPayment = () => {
 
   const requestTossPayment = async () => {
     if (!widgetRef.current) {
-      toast.error("결제 위젯이 초기화되지 않았습니다.");
+      showErrorToast("결제 위젯이 초기화되지 않았습니다.");
       return;
     }
 

--- a/src/feature/payment/hooks/usePaymentModals.tsx
+++ b/src/feature/payment/hooks/usePaymentModals.tsx
@@ -6,8 +6,8 @@ import {
 import { usePaymentStore } from "@feature/payment/stores/paymentStore";
 import { postDefaultTrade, postWifiTrade } from "@feature/payment/api/paymentRequest";
 import { postScrapTrade } from "@feature/payment/api/paymentRequest";
-import { toast } from "react-toastify";
 import { useRouter } from "next/navigation";
+import { showErrorToast } from "@lib/toast";
 
 export default function UsePaymentModals() {
   const router = useRouter();
@@ -100,15 +100,15 @@ export default function UsePaymentModals() {
               const code = error.response?.data?.code;
 
               if (code === 4004) {
-                toast.error("보유 캐시가 부족합니다. 캐시를 충전해주세요!");
+                showErrorToast("보유 캐시가 부족합니다. 캐시를 충전해주세요!");
                 setTimeout(() => {
                   router.push("/mypage/charge");
                 }, 1500);
               } else {
-                toast.error("결제 실패: " + (error.response?.data?.message ?? "알 수 없는 에러"));
+                showErrorToast("결제 실패: " + (error.response?.data?.message ?? "알 수 없는 에러"));
               }
             } else {
-              toast.error("결제 실패: " + (e as Error).message);
+              showErrorToast("결제 실패: " + (e as Error).message);
             }
           }
         }}

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,6 +1,16 @@
-import { toast, Id, ToastContent } from "react-toastify";
+import { toast, Id, ToastContent, ToastOptions, ToastPosition } from "react-toastify";
 
-const defaultOption = {
+interface DefaultOptionType {
+  position: ToastPosition;
+  autoClose: number;
+  hideProgressBar: true;
+  closeOnClick: true;
+  pauseOnHover: false;
+  draggable: false;
+  closeButton: false;
+}
+
+const defaultOption: DefaultOptionType = {
   position: "top-center",
   autoClose: 3000,
   hideProgressBar: true,
@@ -10,19 +20,26 @@ const defaultOption = {
   closeButton: false,
 };
 
+interface OptionType extends ToastOptions {
+  toastClassName: string;
+  bodyClassName: string;
+}
+
 let lastToastId: Id | null = null;
+toast.error("hellp", { containerId: "a" });
 
 const showOnce = (
-  fn: (content: ToastContent, options?: any) => Id,
+  fn: (content: ToastContent, options?: ToastOptions) => Id,
   msg: string,
   toastClassName: string
 ) => {
   if (lastToastId) toast.dismiss(lastToastId);
-  lastToastId = fn(msg, {
+  const customOption: OptionType = {
     ...defaultOption,
-    toastClassName,
+    toastClassName: toastClassName,
     bodyClassName: "text-sm font-medium",
-  });
+  };
+  lastToastId = fn(msg, customOption);
 };
 
 export const showErrorToast = (msg: string) => showOnce(toast.error, msg, "toast-error");

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,0 +1,30 @@
+import { toast, Id, ToastContent } from "react-toastify";
+
+const defaultOption = {
+  position: "top-center",
+  autoClose: 3000,
+  hideProgressBar: true,
+  closeOnClick: true,
+  pauseOnHover: false,
+  draggable: false,
+  closeButton: false,
+};
+
+let lastToastId: Id | null = null;
+
+const showOnce = (
+  fn: (content: ToastContent, options?: any) => Id,
+  msg: string,
+  toastClassName: string
+) => {
+  if (lastToastId) toast.dismiss(lastToastId);
+  lastToastId = fn(msg, {
+    ...defaultOption,
+    toastClassName,
+    bodyClassName: "text-sm font-medium",
+  });
+};
+
+export const showErrorToast = (msg: string) => showOnce(toast.error, msg, "toast-error");
+export const showSuccessToast = (msg: string) => showOnce(toast.success, msg, "toast-secondary");
+export const showInfoToast = (msg: string) => showOnce(toast.info, msg, "toast-secondary");


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->

- 데이터 상품 등록 실패 시 서버에서 전달하는 메시지를 toast로 띄워줌
  - `postMobileDataProduct()`에서 axios 에러 메시지를 추출하여 `throw new Error(...)`로 통일
- 중복 토스트 방지를 위해 마지막 토스트 ID를 기억하여 새 토스트를 띄우기 전에 이전 토스트 닫는 방식 적용
  - `lib/toast.ts`에서 `showErrorToast`, `showSuccessToast` 등 유틸 함수로 정리
  - 동일한 에러 메시지가 반복되지 않도록 UX 개선
- overlimit alert message 수정
  - 등록할때 : 이번 달 최대 판매 가능량을 등록하시겠습니까?
  - 분할구매 : 이번 달 최대 구매 가능 용량에 도달했습니다. 

![toast-duplicate](https://github.com/user-attachments/assets/c6cb478f-92cc-4775-8ec1-e117ef0c8506)

## ✨ 기타 참고 사항

<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->

-

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #316 

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
