### PR TITLE
[DP-164] feat: 현재 이용 가능 스크롤 수정 #126

### DIFF
--- a/src/feature/map/api/mapRequest.ts
+++ b/src/feature/map/api/mapRequest.ts
@@ -22,6 +22,7 @@ export async function getMapList({
   productSortOption = "DISTANCE_ASC",
   latitude = 37.5665,
   longitude = 126.978,
+  open,
 }: FetchMapListParams): Promise<{ items: MapType[]; nextCursor?: number }> {
   const params = {
     size,
@@ -29,6 +30,7 @@ export async function getMapList({
     longitude,
     ...(cursorId !== undefined && { cursorId }),
     ...(productSortOption && { productSortOption }),
+    ...(open !== undefined && { open }),
   };
 
   try {

--- a/src/feature/map/components/sections/product/MapBottomSheet.tsx
+++ b/src/feature/map/components/sections/product/MapBottomSheet.tsx
@@ -53,8 +53,15 @@ export default function MapBottomSheet({
         latitude: myPosition?.lat() ?? 37.5665,
         longitude: myPosition?.lng() ?? 126.978,
         productSortOption: sortOptionMap[sortLabel],
+        open: availableOnly ? true : undefined,
       }),
-    getNextPageParam: (lastPage) => lastPage.nextCursor,
+    getNextPageParam: (lastPage) => {
+      // 🔽 수정 포인트
+      if (availableOnly && lastPage.items.length === 0) {
+        return undefined;
+      }
+      return lastPage.nextCursor;
+    },
     estimateSize: () => 160,
   });
 


### PR DESCRIPTION
## 📌 작업 개요

<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->

- 현재 이용 가능 필터링 버튼 눌렀을 때 스켈레톤만 나오던 부분 새롭게 open=true 인 것을 호출될 수 있도록 수정하였습니다.

## ✨ 기타 참고 사항

-

## 🔗 관련 이슈

<!-- 해당 PR이 어떤 이슈와 연결되는지 명시해주세요 -->

- close #126 

## ✅ 체크리스트

- [x] 현재 Branch에 Merge 대상 Branch를 Merge 하여 코드를 최신화 했나요?
- [x] 모든 Conflict를 수정 완료 했나요?
- [x] Build test를 진행했나요? (npm run build)
- [x] 불필요한 log는 삭제했나요?
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했나요?
